### PR TITLE
Align Python version references with the 3.14 base image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,7 +24,7 @@ updates:
     labels:
       - dependencies
 
-  # Base image (python:3.12-alpine) rebuilds.
+  # Base image (python:3.14-alpine) rebuilds.
   - package-ecosystem: docker
     directory: /
     schedule:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v7
         with:
-          python-version: '3.12'
+          python-version: '3.14'
 
       - name: Install dependencies
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,10 +9,10 @@ This repository contains a lightweight Python Docker service that listens to Doc
 
 ## Commands
 
-A `.venv` (CPython 3.12, matching CI and the runtime image) is already set up at the repo root and is gitignored. Recreate it with:
+A `.venv` (CPython 3.14, matching CI and the runtime image) is already set up at the repo root and is gitignored. Recreate it with:
 
 ```bash
-uv venv --python 3.12
+uv venv --python 3.14
 uv pip install -r requirements.txt -r requirements-dev.txt
 ```
 

--- a/pfsense.py
+++ b/pfsense.py
@@ -15,7 +15,7 @@ The class ensures robust error handling, logs failures without crashing the appl
 and supports secure API interactions using the pfSense API key.
 
 Dependencies:
-- Python 3.12 in the provided Docker image
+- Python 3.14 in the provided Docker image
 - Requests library for HTTP requests
 - urllib3 for TLS warning management when verification is explicitly disabled
 


### PR DESCRIPTION
Follow-up to #4. Merging the base-image bump left the rest of the repo on 3.12.

## The gap

`.github/workflows/docker-publish.yml` still pinned `python-version: '3.12'` for the test job, while the `Dockerfile` now ships `python:3.14-alpine`. **CI was validating a different interpreter than the one that ships** — a 3.14-only regression would have passed every check and gone out untested.

Also updated: `AGENTS.md` (venv setup instructions), `pfsense.py`'s dependency note, and the `dependabot.yml` comment. No remaining `3.12` references in the repo.

## Verification

Ran on Python 3.14.6 before pushing: actionlint clean (with shellcheck on PATH), pylint 10.00/10, both pip-audits clean, 31 tests pass, `docker build` succeeds, and both container smoke tests pass. The local `.venv` was rebuilt on 3.14 so the setup AGENTS.md documents is the one that's actually tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)