### PR TITLE
Apply once per startup scan instead of once per alias

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,9 +80,17 @@ Deliberately asymmetric — keep it that way:
 - `_request` retries `requests.RequestException` up to `API_REQUEST_ATTEMPTS` (3) with a 1s sleep. `raise_for_status()` is called *outside* the retry, so HTTP error statuses are not retried. Tests monkeypatch `pfsense.time.sleep`.
 - Docker event-stream errors **re-raise** out of `main()`; `run()` catches and exits non-zero so the container restarts.
 
-### Mutations are always two calls
+### Mutations are staged, then applied
 
-`add_host_override_alias` and `del_host_override_alias` each perform the mutation, then POST to `/dns_resolver/apply`. Both must succeed to return `True`. Any new mutating method needs the same apply step.
+`add_host_override_alias` and `del_host_override_alias` perform the mutation, then apply it via `apply_changes()` unless called with `apply=False`. Any new mutating method needs the same option.
+
+Applying is the expensive part: it reloads unbound, takes seconds, and **runs asynchronously** — the POST returns before the reload finishes. `apply_changes()` therefore polls `GET /dns_resolver/apply` until the response reports `applied`, up to `APPLY_POLL_ATTEMPTS`, and returns `False` with an error if it never confirms. Treat an unconfirmed reload as a possible lost update, not a success.
+
+That status poll passes `attempts=1` to `_request`. Do not let it use the default retry budget — a retry budget nested inside a poll budget multiplies into a stall long enough to block the event loop.
+
+**Never apply once per item in a loop.** `add_aliases_on_startup` stages every alias with `apply=False` and calls `apply_changes()` exactly once at the end, skipping it entirely when nothing staged. Applying per alias meant 20 containers cost 20 unbound reloads and ~40s of DNS disruption, with overlapping async reloads a likely cause of dropped updates. `tests/test_main.py::test_startup_scan_applies_once_for_many_aliases` pins this by counting.
+
+With `apply=False`, a `True` return means **staged in the pfSense configuration but not yet live**. Staged changes persist and go live on the next successful apply.
 
 `add_host_override_alias` first calls `find_host_name(alias_fqdn)` to reject an alias already used as a host override or alias anywhere, then resolves the parent host override — the override must already exist in pfSense; this service never creates one.
 
@@ -91,7 +99,7 @@ Deliberately asymmetric — keep it that way:
 - `PFSENSE_VERIFY_SSL` is true unless it lowercases to exactly `"false"` (fail-secure). `ADD_ALIASES_ON_STARTUP` is false unless it lowercases to `"true"`.
 - The `pfsense.dns.remove_on_stop` label must be the exact lowercase string `"true"` — case-sensitive, unlike the env vars. There is a test pinning this.
 - `PFSENSE_CA_BUNDLE` wins over `PFSENSE_VERIFY_SSL`: `verify_ssl = ca_bundle if ca_bundle else verify_ssl`, and the result is passed straight to `requests`' `verify=`.
-- Startup sync is additive only — it never prunes stale aliases.
+- Startup sync is additive only — it never prunes stale aliases. It stages every alias and applies once at the end; see "Mutations are staged, then applied".
 
 ### Validation and logging constraints
 

--- a/main.py
+++ b/main.py
@@ -53,7 +53,13 @@ except docker.errors.DockerException as e:
     sys.exit(1)
 
 def add_aliases_on_startup():
-    """Scan all existing Docker containers and add their aliases if not already added."""
+    """
+    Scan all existing Docker containers and add their aliases if not already added.
+
+    Aliases are staged individually and applied once at the end. Applying per alias
+    reloads unbound every time, which takes seconds each and can drop updates when
+    reloads overlap.
+    """
     logger.info("Scanning existing Docker containers for aliases to add...")
     try:
         containers = client.containers.list()
@@ -61,7 +67,8 @@ def add_aliases_on_startup():
         _handle_error(e, "add_aliases_on_startup")
         return
 
-    found = False
+    labeled = 0
+    staged = 0
 
     for container in containers:
         labels = get_container_labels(container)
@@ -70,16 +77,34 @@ def add_aliases_on_startup():
         if not alias_config:
             continue
 
-        logger.info(f"Adding alias '{alias_config['alias_fqdn']}' for container '{container.name}'")
-        NAMESERVER.add_host_override_alias(
+        labeled += 1
+        logger.info(
+            f"Staging alias '{alias_config['alias_fqdn']}' for container '{container.name}'"
+        )
+        if NAMESERVER.add_host_override_alias(
             alias_config["host_override_fqdn"],
             alias_config["alias_fqdn"],
-            alias_config["alias_descr"]
-        )
-        found = True
+            alias_config["alias_descr"],
+            apply=False
+        ):
+            staged += 1
 
-    if not found:
+    if not labeled:
         logger.info("No aliases found during startup.")
+        return
+
+    if not staged:
+        logger.warning(
+            f"Found {labeled} labeled container(s) but staged no aliases; nothing to apply."
+        )
+        return
+
+    logger.info(f"Applying {staged} staged alias(es) in a single reload...")
+    if not NAMESERVER.apply_changes():
+        logger.error(
+            f"{staged} alias(es) are staged in the pfSense configuration but were not "
+            "applied. They will take effect on the next successful apply."
+        )
 
 def cleanup(_signum, _frame):
     """Cleanup actions to perform when the script exits."""

--- a/pfsense.py
+++ b/pfsense.py
@@ -63,6 +63,10 @@ logger = logging.getLogger(__name__)
 
 API_REQUEST_ATTEMPTS = 3
 API_RETRY_DELAY_SECONDS = 1
+# Applying is asynchronous: the POST returns before unbound has finished
+# reloading, so confirm with a bounded GET poll rather than fire-and-forget.
+APPLY_POLL_ATTEMPTS = 15
+APPLY_POLL_DELAY_SECONDS = 1
 DNS_LABEL_PATTERN = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$")
 
 class PFSense:
@@ -94,13 +98,18 @@ class PFSense:
 
         return labels[0], '.'.join(labels[1:])
 
-    def _request(self, method, context, **kwargs):
-        """Run a pfSense API request with a small retry budget for transient failures."""
-        for attempt in range(1, API_REQUEST_ATTEMPTS + 1):
+    def _request(self, method, context, attempts=API_REQUEST_ATTEMPTS, **kwargs):
+        """
+        Run a pfSense API request with a small retry budget for transient failures.
+
+        :param attempts: How many times to try. Callers that already poll pass 1, so a
+            retry budget is not multiplied by a poll budget into a long stall.
+        """
+        for attempt in range(1, attempts + 1):
             try:
                 return method(**kwargs)
             except requests.RequestException as e:
-                if attempt == API_REQUEST_ATTEMPTS:
+                if attempt == attempts:
                     self._handle_api_error(e, context)
                     return None
 
@@ -108,11 +117,84 @@ class PFSense:
                     "API call failed during '%s' attempt %s/%s; retrying.",
                     context,
                     attempt,
-                    API_REQUEST_ATTEMPTS
+                    attempts
                 )
                 time.sleep(API_RETRY_DELAY_SECONDS)
 
         return None
+
+    def _headers(self):
+        """Return the authentication headers for a pfSense API request."""
+        return {
+            'X-API-Key': f"{self.pfsense_api_key}",
+            'Content-Type': 'application/json'
+        }
+
+    def apply_changes(self):
+        """
+        Applies staged DNS resolver changes and waits for the reload to finish.
+
+        pfSense applies changes asynchronously, so the POST returns before unbound has
+        reloaded. Poll the apply endpoint until it reports the change as applied rather
+        than assuming success, because an unconfirmed reload is indistinguishable from a
+        lost update.
+
+        :return: True if the changes were confirmed applied, False otherwise
+        """
+        headers = self._headers()
+        url = f'https://{self.pfsense_host}/api/v2/services/dns_resolver/apply'
+
+        try:
+            response = self._request(
+                requests.post,
+                "apply_changes",
+                url=url,
+                headers=headers,
+                verify=self.verify_ssl,
+                timeout=10
+            )
+            if response is None:
+                return False
+            response.raise_for_status()
+        except requests.RequestException as e:
+            self._handle_api_error(e, "apply_changes")
+            return False
+
+        for attempt in range(1, APPLY_POLL_ATTEMPTS + 1):
+            if self._changes_applied():
+                logger.info("DNS resolver changes applied.")
+                return True
+
+            if attempt < APPLY_POLL_ATTEMPTS:
+                time.sleep(APPLY_POLL_DELAY_SECONDS)
+
+        logger.error(
+            "DNS resolver changes were not confirmed applied after %s attempts. "
+            "They remain staged in the pfSense configuration.",
+            APPLY_POLL_ATTEMPTS
+        )
+        return False
+
+    def _changes_applied(self):
+        """Return True when pfSense reports the staged DNS resolver changes as applied."""
+        try:
+            response = self._request(
+                requests.get,
+                "apply_changes_status",
+                attempts=1,
+                url=f'https://{self.pfsense_host}/api/v2/services/dns_resolver/apply',
+                headers=self._headers(),
+                verify=self.verify_ssl,
+                timeout=10
+            )
+            if response is None:
+                return False
+            response.raise_for_status()
+            data = response.json().get('data', {})
+            return bool(data.get('applied'))
+        except (requests.RequestException, ValueError, AttributeError) as e:
+            self._handle_api_error(e, "apply_changes_status")
+            return False
 
     def _handle_api_error(self, error, context=""):
         """
@@ -192,15 +274,19 @@ class PFSense:
             )
         return alias
 
-    def add_host_override_alias(self, host_override_fqdn, alias_fqdn, alias_descr=""):
-        # pylint: disable=too-many-return-statements
+    def add_host_override_alias(self, host_override_fqdn, alias_fqdn, alias_descr="", apply=True):
+        # pylint: disable=too-many-return-statements,redefined-builtin
         """
         Adds an alias to an existing host override in pfSense.
 
         :param host_override_fqdn: The fully qualified domain name of the existing host override.
         :param alias_fqdn: The fully qualified domain name of the alias to add.
         :param alias_descr: Description for the alias (optional).
-        :return: True if the alias was added, False otherwise
+        :param apply: Apply the change immediately. Pass False when staging several aliases,
+            then call apply_changes() once for the batch — each apply reloads unbound and
+            takes seconds, so applying per alias is both slow and a source of lost updates.
+        :return: True if the alias was added, False otherwise. With apply=False, True means
+            the alias is staged in the pfSense configuration but not yet live.
         """
         split_fqdn = self._split_fqdn(alias_fqdn, "add_host_override_alias")
         if not split_fqdn:
@@ -220,12 +306,6 @@ class PFSense:
             logger.warning(f"Host override {host_override_fqdn} not found.")
             return False
 
-        # Define the headers for authentication
-        headers = {
-            'X-API-Key': f"{self.pfsense_api_key}",
-            'Content-Type': 'application/json'
-        }
-
         data = {
             'parent_id': f'{host_override["id"]}',
             'host': f'{alias_host}',
@@ -238,7 +318,7 @@ class PFSense:
                 requests.post,
                 "add_host_override_alias",
                 url=f'https://{self.pfsense_host}/api/v2/services/dns_resolver/host_override/alias',
-                headers=headers,
+                headers=self._headers(),
                 verify=self.verify_ssl,
                 timeout=10,
                 json=data
@@ -247,32 +327,27 @@ class PFSense:
                 return False
             response.raise_for_status()
 
-            # Apply changes
-            response = self._request(
-                requests.post,
-                "add_host_override_alias_apply",
-                url=f'https://{self.pfsense_host}/api/v2/services/dns_resolver/apply',
-                headers=headers,
-                verify=self.verify_ssl,
-                timeout=10
-            )
-            if response is None:
-                return False
-            response.raise_for_status()
-            logger.info(f"Alias {alias_fqdn} added to host override {host_override_fqdn}.")
-            return True
-
         except requests.RequestException as e:
             self._handle_api_error(e, "add_host_override_alias")
             return False
 
-    def del_host_override_alias(self, host_override_fqdn, alias_fqdn):
+        if apply and not self.apply_changes():
+            return False
+
+        logger.info(f"Alias {alias_fqdn} added to host override {host_override_fqdn}.")
+        return True
+
+    def del_host_override_alias(self, host_override_fqdn, alias_fqdn, apply=True):
+        # pylint: disable=redefined-builtin
         """
         Removes an alias from an existing host override in pfSense.
 
         :param host_override_fqdn: The fully qualified domain name of the existing host override.
         :param alias_fqdn: The fully qualified domain name of the alias to remove.
-        :return: True if the alias was removed, False otherwise
+        :param apply: Apply the change immediately. Pass False when staging several removals,
+            then call apply_changes() once for the batch.
+        :return: True if the alias was removed, False otherwise. With apply=False, True means
+            the removal is staged in the pfSense configuration but not yet live.
         """
         host_override = self.find_host_name(host_override_fqdn)
         if not host_override:
@@ -283,11 +358,6 @@ class PFSense:
         if not alias:
             logger.warning(f"Alias {alias_fqdn} not found in host override {host_override_fqdn}.")
             return False
-
-        headers = {
-            'X-API-Key': f"{self.pfsense_api_key}",
-            'Content-Type': 'application/json'
-        }
 
         data = {
             'parent_id': f'{alias["parent_id"]}',
@@ -300,7 +370,7 @@ class PFSense:
                 requests.delete,
                 "del_host_override_alias",
                 url=f'https://{self.pfsense_host}/api/v2/services/dns_resolver/host_override/alias',
-                headers=headers,
+                headers=self._headers(),
                 verify=self.verify_ssl,
                 timeout=10,
                 json=data
@@ -309,21 +379,12 @@ class PFSense:
                 return False
             response.raise_for_status()
 
-            # Apply changes
-            response = self._request(
-                requests.post,
-                "del_host_override_alias_apply",
-                url=f'https://{self.pfsense_host}/api/v2/services/dns_resolver/apply',
-                headers=headers,
-                verify=self.verify_ssl,
-                timeout=10
-            )
-            if response is None:
-                return False
-            response.raise_for_status()
-            logger.info(f"Alias {alias_fqdn} removed from host override {host_override_fqdn}.")
-            return True
-
         except requests.RequestException as e:
             self._handle_api_error(e, "del_host_override_alias")
             return False
+
+        if apply and not self.apply_changes():
+            return False
+
+        logger.info(f"Alias {alias_fqdn} removed from host override {host_override_fqdn}.")
+        return True

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -239,15 +239,19 @@ def test_add_aliases_on_startup_adds_labeled_running_containers(monkeypatch):
         ),
         types.SimpleNamespace(name="unlabeled", attrs={"Config": {"Labels": {}}}),
     ]
+    applies = []
     main.NAMESERVER = types.SimpleNamespace(
-        add_host_override_alias=lambda host_override, alias, description: calls.append(
-            (host_override, alias, description)
+        add_host_override_alias=lambda host_override, alias, description, apply: calls.append(
+            (host_override, alias, description, apply)
         )
+        or True,
+        apply_changes=lambda: applies.append("apply") or True,
     )
 
     main.add_aliases_on_startup()
 
-    assert calls == [("caddy.lab.internal", "nginx.lab.internal", "nginx service")]
+    assert calls == [("caddy.lab.internal", "nginx.lab.internal", "nginx service", False)]
+    assert applies == ["apply"]
 
 
 def test_handle_container_event_dispatches_stop_when_enabled(monkeypatch):
@@ -558,3 +562,101 @@ def test_main_runs_startup_scan_only_when_enabled(monkeypatch):
     main.main()
 
     assert scanned == []
+
+
+# --- Startup batching: one reload, not one per alias --------------------------
+
+
+def _labeled_container(name, alias):
+    return types.SimpleNamespace(
+        name=name,
+        attrs={
+            "Config": {
+                "Labels": {
+                    "pfsense.dns.override": "caddy.lab.internal",
+                    "pfsense.dns.alias": alias,
+                    "pfsense.dns.description": f"{name} service",
+                }
+            }
+        },
+    )
+
+
+def _recording_nameserver(staged, applies, add_result=True, apply_result=True):
+    return types.SimpleNamespace(
+        add_host_override_alias=lambda host_override, alias, description, apply: (
+            staged.append((alias, apply)) or add_result
+        ),
+        apply_changes=lambda: applies.append("apply") or apply_result,
+    )
+
+
+def test_startup_scan_applies_once_for_many_aliases(monkeypatch):
+    """The regression this change exists for: N aliases must cost one reload, not N."""
+    main, fake_client = load_main(monkeypatch)
+    staged = []
+    applies = []
+    fake_client.containers.list = lambda: [
+        _labeled_container(f"svc{i}", f"svc{i}.lab.internal") for i in range(20)
+    ]
+    main.NAMESERVER = _recording_nameserver(staged, applies)
+
+    main.add_aliases_on_startup()
+
+    assert len(staged) == 20
+    assert all(apply is False for _alias, apply in staged)
+    assert applies == ["apply"]
+
+
+def test_startup_scan_does_not_apply_when_nothing_was_staged(monkeypatch):
+    main, fake_client = load_main(monkeypatch)
+    staged = []
+    applies = []
+    fake_client.containers.list = lambda: [
+        types.SimpleNamespace(name="plain", attrs={"Config": {"Labels": {}}})
+    ]
+    main.NAMESERVER = _recording_nameserver(staged, applies)
+
+    main.add_aliases_on_startup()
+
+    assert staged == []
+    assert applies == []
+
+
+def test_startup_scan_does_not_apply_when_every_stage_failed(monkeypatch, caplog):
+    main, fake_client = load_main(monkeypatch)
+    staged = []
+    applies = []
+    fake_client.containers.list = lambda: [
+        _labeled_container("svc0", "svc0.lab.internal"),
+        _labeled_container("svc1", "svc1.lab.internal"),
+    ]
+    main.NAMESERVER = _recording_nameserver(staged, applies, add_result=False)
+
+    with caplog.at_level(logging.WARNING):
+        main.add_aliases_on_startup()
+
+    assert len(staged) == 2
+    assert applies == []
+    # Labeled-but-unstaged must not be reported as "no aliases found" — that
+    # hid a real failure while looking like an idle startup.
+    assert "Found 2 labeled container(s)" in caplog.text
+    assert "No aliases found during startup" not in caplog.text
+
+
+def test_startup_scan_reports_staged_aliases_when_the_apply_fails(monkeypatch, caplog):
+    main, fake_client = load_main(monkeypatch)
+    staged = []
+    applies = []
+    fake_client.containers.list = lambda: [
+        _labeled_container("svc0", "svc0.lab.internal"),
+        _labeled_container("svc1", "svc1.lab.internal"),
+    ]
+    main.NAMESERVER = _recording_nameserver(staged, applies, apply_result=False)
+
+    with caplog.at_level(logging.ERROR):
+        main.add_aliases_on_startup()
+
+    assert applies == ["apply"]
+    assert "2 alias(es) are staged" in caplog.text
+    assert "next successful apply" in caplog.text

--- a/tests/test_pfsense.py
+++ b/tests/test_pfsense.py
@@ -1,6 +1,7 @@
 import requests
 import logging
 
+import pfsense
 from pfsense import PFSense
 
 
@@ -24,6 +25,11 @@ def http_error():
     error = requests.HTTPError("request failed")
     error.response = response
     return error
+
+
+def applied_status_get(applied=True):
+    """A requests.get stand-in for the apply endpoint's status poll."""
+    return lambda **_kwargs: FakeResponse({"data": {"applied": applied}})
 
 
 def test_get_all_host_overrides_constructs_request(monkeypatch):
@@ -178,6 +184,7 @@ def test_add_host_override_alias_constructs_alias_and_apply_requests(monkeypatch
         return FakeResponse()
 
     monkeypatch.setattr("pfsense.requests.post", fake_post)
+    monkeypatch.setattr("pfsense.requests.get", applied_status_get())
 
     client = PFSense("pfsense.lab.internal", "secret-token", verify_ssl=False)
     client.get_all_host_overrides = lambda: [
@@ -221,6 +228,61 @@ def test_add_host_override_alias_constructs_alias_and_apply_requests(monkeypatch
             "json": None,
         },
     ]
+
+
+def test_add_host_override_alias_can_stage_without_applying(monkeypatch):
+    posts = []
+    gets = []
+
+    monkeypatch.setattr(
+        "pfsense.requests.post",
+        lambda url, **_kwargs: posts.append(url) or FakeResponse(),
+    )
+    monkeypatch.setattr(
+        "pfsense.requests.get",
+        lambda url, **_kwargs: gets.append(url) or FakeResponse(),
+    )
+
+    client = PFSense("pfsense.lab.internal", "secret-token")
+    client.get_all_host_overrides = lambda: [
+        {"id": 12, "host": "caddy", "domain": "lab.internal", "aliases": []}
+    ]
+
+    assert client.add_host_override_alias(
+        "caddy.lab.internal", "nginx.lab.internal", "nginx service", apply=False
+    )
+
+    assert posts == [
+        "https://pfsense.lab.internal/api/v2/services/dns_resolver/host_override/alias"
+    ]
+    assert gets == []
+
+
+def test_del_host_override_alias_can_stage_without_applying(monkeypatch):
+    posts = []
+
+    monkeypatch.setattr("pfsense.requests.delete", lambda **_kwargs: FakeResponse())
+    monkeypatch.setattr(
+        "pfsense.requests.post",
+        lambda url, **_kwargs: posts.append(url) or FakeResponse(),
+    )
+
+    client = PFSense("pfsense.lab.internal", "secret-token")
+    client.get_all_host_overrides = lambda: [
+        {
+            "id": 12,
+            "host": "caddy",
+            "domain": "lab.internal",
+            "aliases": [
+                {"id": 34, "parent_id": 12, "host": "nginx", "domain": "lab.internal"}
+            ],
+        }
+    ]
+
+    assert client.del_host_override_alias(
+        "caddy.lab.internal", "nginx.lab.internal", apply=False
+    )
+    assert posts == []
 
 
 def test_add_host_override_alias_returns_false_when_api_post_fails(monkeypatch):
@@ -330,6 +392,7 @@ def test_del_host_override_alias_constructs_delete_and_apply_requests(monkeypatc
 
     monkeypatch.setattr("pfsense.requests.delete", fake_delete)
     monkeypatch.setattr("pfsense.requests.post", fake_post)
+    monkeypatch.setattr("pfsense.requests.get", applied_status_get())
 
     client = PFSense("pfsense.lab.internal", "secret-token", verify_ssl=False)
     client.get_all_host_overrides = lambda: [
@@ -590,3 +653,105 @@ def test_del_host_override_alias_returns_false_when_delete_exhausts_retries(monk
 
     assert not client.del_host_override_alias("caddy.lab.internal", "nginx.lab.internal")
     assert calls == ["delete", "delete", "delete"]
+
+
+def test_apply_changes_confirms_the_reload_landed(monkeypatch):
+    posts = []
+    gets = []
+
+    monkeypatch.setattr(
+        "pfsense.requests.post",
+        lambda url, **_kwargs: posts.append(url) or FakeResponse(),
+    )
+    monkeypatch.setattr(
+        "pfsense.requests.get",
+        lambda url, **_kwargs: gets.append(url) or FakeResponse({"data": {"applied": True}}),
+    )
+
+    client = PFSense("pfsense.lab.internal", "secret-token")
+
+    assert client.apply_changes() is True
+    assert posts == ["https://pfsense.lab.internal/api/v2/services/dns_resolver/apply"]
+    assert gets == ["https://pfsense.lab.internal/api/v2/services/dns_resolver/apply"]
+
+
+def test_apply_changes_polls_until_pfsense_reports_applied(monkeypatch):
+    monkeypatch.setattr("pfsense.time.sleep", lambda _seconds: None)
+    monkeypatch.setattr("pfsense.requests.post", lambda **_kwargs: FakeResponse())
+
+    polls = []
+
+    def slow_apply(**_kwargs):
+        polls.append("get")
+        return FakeResponse({"data": {"applied": len(polls) >= 3}})
+
+    monkeypatch.setattr("pfsense.requests.get", slow_apply)
+
+    client = PFSense("pfsense.lab.internal", "secret-token")
+
+    assert client.apply_changes() is True
+    assert len(polls) == 3
+
+
+def test_apply_changes_gives_up_and_reports_changes_still_staged(monkeypatch, caplog):
+    monkeypatch.setattr("pfsense.time.sleep", lambda _seconds: None)
+    monkeypatch.setattr("pfsense.requests.post", lambda **_kwargs: FakeResponse())
+    monkeypatch.setattr("pfsense.requests.get", applied_status_get(applied=False))
+
+    client = PFSense("pfsense.lab.internal", "secret-token")
+
+    with caplog.at_level(logging.ERROR):
+        assert client.apply_changes() is False
+
+    assert "remain staged" in caplog.text
+
+
+def test_apply_changes_returns_false_when_the_apply_post_fails(monkeypatch):
+    monkeypatch.setattr("pfsense.time.sleep", lambda _seconds: None)
+    monkeypatch.setattr(
+        "pfsense.requests.post",
+        lambda **_kwargs: FakeResponse(error=http_error()),
+    )
+    gets = []
+    monkeypatch.setattr(
+        "pfsense.requests.get", lambda **_kwargs: gets.append("get") or FakeResponse()
+    )
+
+    client = PFSense("pfsense.lab.internal", "secret-token")
+
+    assert client.apply_changes() is False
+    assert gets == []
+
+
+def test_apply_changes_status_poll_does_not_multiply_the_retry_budget(monkeypatch):
+    """A failing status poll must not stack _request retries inside the poll loop."""
+    monkeypatch.setattr("pfsense.time.sleep", lambda _seconds: None)
+    monkeypatch.setattr("pfsense.requests.post", lambda **_kwargs: FakeResponse())
+
+    attempts = []
+
+    def unreachable(**_kwargs):
+        attempts.append("get")
+        raise requests.ConnectionError("unreachable")
+
+    monkeypatch.setattr("pfsense.requests.get", unreachable)
+
+    client = PFSense("pfsense.lab.internal", "secret-token")
+
+    assert client.apply_changes() is False
+    assert len(attempts) == pfsense.APPLY_POLL_ATTEMPTS
+
+
+def test_apply_changes_treats_a_malformed_status_body_as_not_applied(monkeypatch):
+    monkeypatch.setattr("pfsense.time.sleep", lambda _seconds: None)
+    monkeypatch.setattr("pfsense.requests.post", lambda **_kwargs: FakeResponse())
+
+    class InvalidJson(FakeResponse):
+        def json(self):
+            raise ValueError("not json")
+
+    monkeypatch.setattr("pfsense.requests.get", lambda **_kwargs: InvalidJson())
+
+    client = PFSense("pfsense.lab.internal", "secret-token")
+
+    assert client.apply_changes() is False


### PR DESCRIPTION
Fixes the pfSense pummeling you spotted with `ADD_ALIASES_ON_STARTUP=true`. Your read was right, and it was worse than one reload per alias.

## What was happening

`add_aliases_on_startup` called `add_host_override_alias` per container, and each of those issued **four** HTTP requests: two full `GET /host_overrides` (duplicate check, then parent lookup), the create, and a `POST /apply` — a full unbound reload.

Measured with an instrumented stub:

| | Before | After |
|---|---|---|
| HTTP requests (N=20) | 80 | 62 |
| **unbound reloads** | **20** | **1** |

At a couple of seconds per reload that's ~40s of repeated DNS restarts every startup.

## Why updates were getting lost

Per the [vendor docs](https://pfrest.org/COMMON_CONTROL_PARAMETERS/), apply endpoints run **asynchronously by default** — `POST /apply` returns *before* unbound has finished reloading — and the docs explicitly recommend polling `GET` on the apply endpoint instead of fire-and-forget, warning that unverified rapid calls "could create unpredictable behavior or resource contention."

The old code fired 20 overlapping, unverified reloads. Config writes landing while a previous reload is still in flight is exactly the shape of a lost update.

## The change

- **`PFSense.apply_changes()`** — POSTs the apply, then polls `GET` until pfSense reports `applied`, up to `APPLY_POLL_ATTEMPTS`. Returns `False` and logs when it never confirms, so an unconfirmed reload stops looking like success.
- **`apply=True` keyword** on `add_`/`del_host_override_alias`. With `apply=False` the mutation is staged and `True` means *staged, not live*.
- **`add_aliases_on_startup`** stages everything with `apply=False`, then applies once — skipping the apply entirely when nothing staged. It also now counts real successes; previously the return value was discarded and `found` was set on label presence alone.

Ruled out: the plural `/host_override/aliases` endpoint. Its `PUT` **replaces the entire set, deleting anything not listed**, which would wipe aliases created by hand in the pfSense UI.

## Two things the work turned up

**A stall I introduced and caught.** The status poll initially used `_request`'s default retry budget, nesting retries inside the poll loop — worst case ~60s of blocking, long enough to stall the event loop. It announced itself by making the test suite take 90 seconds. `_request` grew an `attempts` parameter; the poll passes `attempts=1`.

**A misleading log message.** Labeled containers that all failed to stage previously logged "No aliases found during startup" — a real failure that looked like an idle startup. Now distinguished, and pinned by a test.

## Contract change

This deliberately amends the **"mutations are always two calls"** invariant. Four tests asserting the exact create-then-apply sequence were revised as a planned change, not softened to reach green — `AGENTS.md` is updated to match, and the new `test_startup_scan_applies_once_for_many_aliases` pins the fix by counting reloads.

## Not in scope

- **Event-burst coalescing** — `docker compose up` with 20 labeled services still fires 20 events and 20 applies. Same pathology, but debouncing needs a background timer against the blocking event loop. Worth its own PR.
- **The 40 redundant `GET`s** — two full host-override fetches per alias could collapse to one cached snapshot. Deferred: reloads were the seconds-long part, and a stale cache trades correctness risk for a smaller win.

## Verification

69 tests (12 new), 99.23% coverage, pylint 10.00/10, actionlint clean, both audits clean, image builds, both smoke tests pass. A real 3-container startup scan against an unreachable host stages each alias, reports accurately, issues zero applies, and stays running.

**Still untested against a real pfSense** — worth confirming on your instance that all aliases appear after the single reload before this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)