### PR TITLE
Coalesce event-driven applies into one reload per burst

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,27 @@ That status poll passes `attempts=1` to `_request`. Do not let it use the defaul
 
 **Never apply once per item in a loop.** `add_aliases_on_startup` stages every alias with `apply=False` and calls `apply_changes()` exactly once at the end, skipping it entirely when nothing staged. Applying per alias meant 20 containers cost 20 unbound reloads and ~40s of DNS disruption, with overlapping async reloads a likely cause of dropped updates. `tests/test_main.py::test_startup_scan_applies_once_for_many_aliases` pins this by counting.
 
+### Event-driven applies are coalesced
+
+The same burst arrives through the event loop — a `docker compose up` of twenty labeled services fires twenty events. `process_start_event` and `process_stop_event` therefore consult `should_apply_immediately()`:
+
+- The **first** change after a quiet period applies immediately, so a lone container start is as fast as it was before coalescing.
+- Everything during the burst that follows is staged with `apply=False` and flushed by one `apply_changes()`.
+
+`flush_pending_changes()` fires when `APPLY_QUIET_SECONDS` (default 10) passes with no new change, when `APPLY_MAX_WAIT_SECONDS` (default 60) caps the wait so continuous churn cannot starve the apply, or with `force=True` on shutdown. Twenty services cost two reloads instead of twenty; `test_a_burst_of_starts_costs_two_applies_not_twenty` pins it.
+
+Coalescing state (`PENDING_CHANGES`, `PENDING_SINCE`, `LAST_CHANGE_AT`, `LAST_APPLY_AT`) is module level and measured with `time.monotonic()`, so a wall-clock adjustment cannot strand pending changes. Note that `LAST_APPLY_AT = 0.0` reads as *long ago*, not *just now* — tests that need "an apply just happened" must set `time.monotonic()`.
+
+**`cleanup()` flushes before exit.** A SIGTERM with staged changes would otherwise leave them in the config but never live. It guards on `NAMESERVER is not None`, since a signal can arrive before `main()` constructs it, and swallows flush errors so a broken apply cannot block shutdown. Docker's default 10s stop grace can still cut a slow apply short; the changes stay staged and go live on the next apply.
+
+### The event loop yields window ticks
+
+`iter_events()` replaces a single blocking `client.events()` with contiguous bounded windows (`since`/`until`, `EVENT_WINDOW_SECONDS`), yielding `None` at each boundary so `main()` can call `flush_pending_changes()`. This keeps the loop **single threaded** — no timer thread, no lock, no signal-handler reentrancy — which is why the resilience contract still holds.
+
+Windows are contiguous, so events between them are still delivered. An event landing exactly on a boundary may be delivered twice; that is harmless because adding an existing alias or removing an absent one is already detected and logged.
+
+Tests drive `main()` by monkeypatching `main.iter_events` with a finite iterable. Do not stub `client.events` for loop tests — `iter_events` loops forever by design, so main() would never return.
+
 With `apply=False`, a `True` return means **staged in the pfSense configuration but not yet live**. Staged changes persist and go live on the next successful apply.
 
 `add_host_override_alias` first calls `find_host_name(alias_fqdn)` to reject an alias already used as a host override or alias anywhere, then resolves the parent host override — the override must already exist in pfSense; this service never creates one.

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ docker run \
 - Set `PFSENSE_API_TOKEN` in your shell or Compose `.env` file instead of hardcoding the token in `docker-compose.yaml`.
 - Ensure the required environment variables (`PFSENSE_HOSTNAME`, `PFSENSE_API_TOKEN`) are correctly set.
 - If using `ADD_ALIASES_ON_STARTUP`, ensure all currently running containers are labeled correctly before starting the service. Startup sync is additive and does not prune stale aliases.
+- A single container start applies right away. When several containers start at once — a `docker compose up`, or a startup scan — the changes are batched and applied in one DNS resolver reload rather than one per alias. A lone alias is therefore live in seconds, while a burst of twenty costs two reloads instead of twenty. Tune with `APPLY_QUIET_SECONDS` if your services start staggered over a longer period.
 - Replace `pfsense.lab.internal` with the fully qualified hostname or IP address of your pfSense firewall.
 - Mounting `/var/run/docker.sock` gives this service broad access to the Docker host. Run it only on trusted hosts and with a pfSense API token scoped as narrowly as your installation allows.
 
@@ -167,6 +168,8 @@ Use these environment variables in your `docker-compose.yaml` or `docker run` co
 | `PFSENSE_VERIFY_SSL`     | No       | `true`  | Validate the pfSense HTTPS certificate. Set to `false` only if certificate validation is not possible. |
 | `PFSENSE_CA_BUNDLE`      | No       | None    | Path inside the container to a custom CA bundle for pfSense certificate validation. |
 | `ADD_ALIASES_ON_STARTUP` | No       | `false` | Add aliases for currently running labeled containers on startup. |
+| `APPLY_QUIET_SECONDS`    | No       | `10`    | Seconds without a new container event before staged DNS changes are applied together. Applying reloads the pfSense DNS resolver and takes a few seconds, so bursts are batched into one reload. |
+| `APPLY_MAX_WAIT_SECONDS` | No       | `60`    | Upper bound on how long staged changes wait, so continuous container churn cannot delay them indefinitely. |
 
 ### Docker Labels
 Use these labels on your services to automatically generate aliases in pfSense DNS.

--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ DNS aliases in pfSense based on labels defined in the container configuration.
 
 import os
 import sys
+import time
 import signal
 import logging
 import docker
@@ -39,11 +40,43 @@ def get_env_var(var_name):
         sys.exit(1)
     return value
 
+def get_positive_float_env(var_name, default):
+    """Read a positive float environment variable, falling back to default if unusable."""
+    raw = os.getenv(var_name)
+    if raw is None:
+        return default
+
+    try:
+        value = float(raw)
+    except ValueError:
+        logger.warning(f"Ignoring invalid {var_name}='{raw}'; using {default}.")
+        return default
+
+    if value <= 0:
+        logger.warning(f"Ignoring non-positive {var_name}='{raw}'; using {default}.")
+        return default
+
+    return value
+
 PFSENSE_HOSTNAME = get_env_var("PFSENSE_HOSTNAME")
 PFSENSE_API_TOKEN = get_env_var("PFSENSE_API_TOKEN")
 PFSENSE_VERIFY_SSL = os.getenv("PFSENSE_VERIFY_SSL", "true").lower() != "false"
 PFSENSE_CA_BUNDLE = os.getenv("PFSENSE_CA_BUNDLE")
 ADD_ALIASES_ON_STARTUP = os.getenv("ADD_ALIASES_ON_STARTUP", "false").lower() == "true"
+# Coalescing: a burst of container events (a compose up) should cost one reload, not
+# one per container. The first change in a quiet period still applies immediately so a
+# lone container start is as fast as it ever was.
+APPLY_QUIET_SECONDS = get_positive_float_env("APPLY_QUIET_SECONDS", 10.0)
+APPLY_MAX_WAIT_SECONDS = get_positive_float_env("APPLY_MAX_WAIT_SECONDS", 60.0)
+# How often the event loop regains control to check whether a flush is due.
+EVENT_WINDOW_SECONDS = 2.0
+
+# Coalescing state. Elapsed time uses a monotonic clock so a wall-clock adjustment
+# cannot strand pending changes.
+PENDING_CHANGES = 0
+PENDING_SINCE = None
+LAST_CHANGE_AT = None
+LAST_APPLY_AT = None
 
 # Initialize Docker client
 try:
@@ -109,6 +142,12 @@ def add_aliases_on_startup():
 def cleanup(_signum, _frame):
     """Cleanup actions to perform when the script exits."""
     logger.info("Shutting down gracefully...")
+    try:
+        if NAMESERVER is not None:
+            flush_pending_changes(force=True)
+    except Exception as e: # pylint: disable=broad-except
+        _handle_error(e, "cleanup")
+
     try:
         client.close()
     except docker.errors.DockerException as e:
@@ -194,15 +233,113 @@ def handle_container_event(event):
         logger.info(f"Container '{container.name}' is stopping...")
         process_stop_event(alias_config["host_override_fqdn"], alias_config["alias_fqdn"])
 
+def should_apply_immediately():
+    """
+    True when a change can be applied on its own rather than coalesced.
+
+    The first change after a quiet period applies immediately, so a single container
+    start is as fast as it was before coalescing. Anything arriving during the burst
+    that follows is staged and flushed together.
+    """
+    if PENDING_CHANGES:
+        return False
+    return LAST_APPLY_AT is None or time.monotonic() - LAST_APPLY_AT >= APPLY_QUIET_SECONDS
+
+def _record_staged():
+    """Note that a change is staged in pfSense but not yet applied."""
+    global PENDING_CHANGES, PENDING_SINCE, LAST_CHANGE_AT  # pylint: disable=global-statement
+    PENDING_CHANGES += 1
+    LAST_CHANGE_AT = time.monotonic()
+    if PENDING_SINCE is None:
+        PENDING_SINCE = LAST_CHANGE_AT
+
+def _record_applied():
+    """Reset coalescing state after changes have been applied."""
+    global PENDING_CHANGES, PENDING_SINCE, LAST_CHANGE_AT, LAST_APPLY_AT  # pylint: disable=global-statement
+    PENDING_CHANGES = 0
+    PENDING_SINCE = None
+    LAST_CHANGE_AT = None
+    LAST_APPLY_AT = time.monotonic()
+
+def _flush_reason(force):
+    """Describe why a flush is due, or None when it is not yet time."""
+    if force:
+        return "shutdown"
+    if time.monotonic() - LAST_CHANGE_AT >= APPLY_QUIET_SECONDS:
+        return f"{APPLY_QUIET_SECONDS:g}s without a new event"
+    if time.monotonic() - PENDING_SINCE >= APPLY_MAX_WAIT_SECONDS:
+        return f"{APPLY_MAX_WAIT_SECONDS:g}s maximum wait"
+    return None
+
+def flush_pending_changes(force=False):
+    """
+    Apply coalesced changes once the quiet window passes, the max wait elapses, or on
+    shutdown. Does nothing when no changes are pending.
+    """
+    if not PENDING_CHANGES:
+        return
+
+    reason = _flush_reason(force)
+    if reason is None:
+        return
+
+    count = PENDING_CHANGES
+    logger.info(f"Applying {count} coalesced change(s) after {reason}...")
+    applied = NAMESERVER.apply_changes()
+    _record_applied()
+
+    if not applied:
+        logger.error(
+            f"{count} change(s) are staged in the pfSense configuration but were not "
+            "applied. They will take effect on the next successful apply."
+        )
+
 def process_start_event(host_override_fqdn, alias_fqdn, alias_descr):
     """Process a container start event and add an alias if necessary."""
-    NAMESERVER.add_host_override_alias(host_override_fqdn, alias_fqdn, alias_descr)
+    immediate = should_apply_immediately()
+    if not NAMESERVER.add_host_override_alias(
+        host_override_fqdn, alias_fqdn, alias_descr, apply=immediate
+    ):
+        return
+
+    if immediate:
+        _record_applied()
+    else:
+        _record_staged()
 
 def process_stop_event(host_override_fqdn, alias_fqdn):
     """Process a container stop event and remove an alias if necessary."""
-    NAMESERVER.del_host_override_alias(host_override_fqdn, alias_fqdn)
+    immediate = should_apply_immediately()
+    if not NAMESERVER.del_host_override_alias(host_override_fqdn, alias_fqdn, apply=immediate):
+        return
+
+    if immediate:
+        _record_applied()
+    else:
+        _record_staged()
 
 NAMESERVER = None
+
+def iter_events():
+    """
+    Yield Docker events, with a None tick at every window boundary.
+
+    `client.events()` blocks indefinitely, which would leave nowhere to notice that a
+    quiet period has elapsed and pending changes are due. Streaming bounded windows
+    hands control back on a fixed cadence without a timer thread, keeping the event
+    loop single threaded and the signal handlers simple.
+
+    Windows are contiguous — each starts where the previous ended — so events arriving
+    between windows are still delivered. An event landing exactly on a boundary may be
+    delivered twice; that is harmless, because adding an existing alias or removing an
+    absent one is already detected and logged rather than duplicated.
+    """
+    since = time.time()
+    while True:
+        until = time.time() + EVENT_WINDOW_SECONDS
+        yield from client.events(since=since, until=until, decode=True)
+        since = until
+        yield None
 
 def main():
     """Main program loop to listen for Docker events."""
@@ -220,8 +357,11 @@ def main():
 
     try:
         logger.info("Listening for container start/stop events.")
-        for event in client.events(decode=True):
-            if event.get('Type') == 'container' and event.get('Action') in ['start', 'stop', 'die']:
+        for event in iter_events():
+            if event is None:
+                flush_pending_changes()
+            elif (event.get('Type') == 'container'
+                  and event.get('Action') in ['start', 'stop', 'die']):
                 handle_container_event(event)
     except docker.errors.DockerException as e:
         _handle_error(e, "main")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,7 @@
 import importlib
 import logging
 import sys
+import time
 import types
 
 
@@ -17,12 +18,14 @@ class FakeDockerClient:
         self.containers = types.SimpleNamespace(get=self.get_container, list=lambda: [])
         self.container = None
         self.closed = False
+        self.event_windows = []
 
     def get_container(self, _container_id):
         return self.container
 
-    def events(self, decode=True):
+    def events(self, since=None, until=None, decode=True):
         assert decode is True
+        self.event_windows.append((since, until))
         return iter(())
 
     def close(self):
@@ -183,16 +186,20 @@ def test_handle_container_event_ignores_missing_container_id(monkeypatch, caplog
 
 
 def test_main_loop_ignores_malformed_events(monkeypatch):
-    main, fake_client = load_main(monkeypatch)
+    main, _fake_client = load_main(monkeypatch)
     handled_events = []
-    fake_client.events = lambda decode=True: iter(
-        [
-            {},
-            {"Type": "container"},
-            {"Type": "network", "Action": "start"},
-            {"Type": "container", "Action": "start"},
-            {"Type": "container", "Action": "die"},
-        ]
+    monkeypatch.setattr(
+        main,
+        "iter_events",
+        lambda: iter(
+            [
+                {},
+                {"Type": "container"},
+                {"Type": "network", "Action": "start"},
+                {"Type": "container", "Action": "start"},
+                {"Type": "container", "Action": "die"},
+            ]
+        ),
     )
     monkeypatch.setattr(main, "handle_container_event", handled_events.append)
 
@@ -204,14 +211,29 @@ def test_main_loop_ignores_malformed_events(monkeypatch):
     ]
 
 
-def test_main_loop_reraises_docker_event_errors(monkeypatch):
-    main, fake_client = load_main(monkeypatch)
+def test_main_loop_flushes_pending_changes_on_a_window_tick(monkeypatch):
+    main, _fake_client = load_main(monkeypatch)
+    flushes = []
+    monkeypatch.setattr(
+        main,
+        "iter_events",
+        lambda: iter([{"Type": "container", "Action": "start"}, None, None]),
+    )
+    monkeypatch.setattr(main, "handle_container_event", lambda _event: None)
+    monkeypatch.setattr(main, "flush_pending_changes", lambda: flushes.append("flush"))
 
-    def fail_events(decode=True):
-        assert decode is True
+    main.main()
+
+    assert flushes == ["flush", "flush"]
+
+
+def test_main_loop_reraises_docker_event_errors(monkeypatch):
+    main, _fake_client = load_main(monkeypatch)
+
+    def fail_events():
         raise DockerException("event stream failed")
 
-    fake_client.events = fail_events
+    monkeypatch.setattr(main, "iter_events", fail_events)
 
     try:
         main.main()
@@ -535,20 +557,27 @@ def test_process_events_delegate_to_nameserver(monkeypatch):
     added = []
     removed = []
     main.NAMESERVER = types.SimpleNamespace(
-        add_host_override_alias=lambda host, alias, descr: added.append((host, alias, descr)),
-        del_host_override_alias=lambda host, alias: removed.append((host, alias)),
+        add_host_override_alias=lambda host, alias, descr, apply: added.append(
+            (host, alias, descr, apply)
+        )
+        or True,
+        del_host_override_alias=lambda host, alias, apply: removed.append((host, alias, apply))
+        or True,
     )
 
     main.process_start_event("caddy.lab.internal", "nginx.lab.internal", "nginx service")
     main.process_stop_event("caddy.lab.internal", "nginx.lab.internal")
 
-    assert added == [("caddy.lab.internal", "nginx.lab.internal", "nginx service")]
-    assert removed == [("caddy.lab.internal", "nginx.lab.internal")]
+    # The first change in a quiet period applies immediately; the second coalesces
+    # because an apply just happened.
+    assert added == [("caddy.lab.internal", "nginx.lab.internal", "nginx service", True)]
+    assert removed == [("caddy.lab.internal", "nginx.lab.internal", False)]
 
 
 def test_main_runs_startup_scan_only_when_enabled(monkeypatch):
     main, _fake_client = load_main(monkeypatch, add_on_startup="true")
     scanned = []
+    monkeypatch.setattr(main, "iter_events", lambda: iter(()))
     monkeypatch.setattr(main, "add_aliases_on_startup", lambda: scanned.append(True))
 
     main.main()
@@ -557,6 +586,7 @@ def test_main_runs_startup_scan_only_when_enabled(monkeypatch):
 
     main, _fake_client = load_main(monkeypatch)
     scanned = []
+    monkeypatch.setattr(main, "iter_events", lambda: iter(()))
     monkeypatch.setattr(main, "add_aliases_on_startup", lambda: scanned.append(True))
 
     main.main()
@@ -660,3 +690,276 @@ def test_startup_scan_reports_staged_aliases_when_the_apply_fails(monkeypatch, c
     assert applies == ["apply"]
     assert "2 alias(es) are staged" in caplog.text
     assert "next successful apply" in caplog.text
+
+
+# --- Coalescing: a burst costs one reload, a lone start stays fast -------------
+
+
+class RecordingNameserver:
+    """Counts applies, distinguishing immediate ones from coalesced flushes."""
+
+    def __init__(self, apply_result=True):
+        self.staged = []
+        self.immediate_applies = 0
+        self.flush_applies = 0
+        self.apply_result = apply_result
+
+    def add_host_override_alias(self, _host_override, alias, _descr, apply):
+        self.staged.append((alias, apply))
+        if apply:
+            self.immediate_applies += 1
+        return True
+
+    def del_host_override_alias(self, _host_override, alias, apply):
+        self.staged.append((alias, apply))
+        if apply:
+            self.immediate_applies += 1
+        return True
+
+    def apply_changes(self):
+        self.flush_applies += 1
+        return self.apply_result
+
+    @property
+    def total_applies(self):
+        return self.immediate_applies + self.flush_applies
+
+
+def test_a_lone_container_start_applies_immediately(monkeypatch):
+    main, _fake_client = load_main(monkeypatch)
+    nameserver = RecordingNameserver()
+    main.NAMESERVER = nameserver
+
+    main.process_start_event("caddy.lab.internal", "svc.lab.internal", "svc")
+
+    assert nameserver.staged == [("svc.lab.internal", True)]
+    assert nameserver.immediate_applies == 1
+    assert main.PENDING_CHANGES == 0
+
+
+def test_a_burst_of_starts_costs_two_applies_not_twenty(monkeypatch):
+    """The regression this change exists for: a compose up must not reload per service."""
+    main, _fake_client = load_main(monkeypatch)
+    nameserver = RecordingNameserver()
+    main.NAMESERVER = nameserver
+
+    for i in range(20):
+        main.process_start_event("caddy.lab.internal", f"svc{i}.lab.internal", "svc")
+
+    # The first applied on its own; the remaining 19 are staged and still pending.
+    assert nameserver.immediate_applies == 1
+    assert main.PENDING_CHANGES == 19
+    assert [apply for _alias, apply in nameserver.staged] == [True] + [False] * 19
+
+    # A window tick after the quiet period flushes all 19 in one apply.
+    monkeypatch.setattr(main, "APPLY_QUIET_SECONDS", 0.0)
+    main.flush_pending_changes()
+
+    assert nameserver.flush_applies == 1
+    assert nameserver.total_applies == 2
+    assert main.PENDING_CHANGES == 0
+
+
+def test_pending_changes_are_not_flushed_before_the_quiet_period(monkeypatch):
+    main, _fake_client = load_main(monkeypatch)
+    nameserver = RecordingNameserver()
+    main.NAMESERVER = nameserver
+    monkeypatch.setattr(main, "APPLY_QUIET_SECONDS", 3600.0)
+    monkeypatch.setattr(main, "APPLY_MAX_WAIT_SECONDS", 3600.0)
+
+    main.process_start_event("caddy.lab.internal", "a.lab.internal", "a")
+    main.process_start_event("caddy.lab.internal", "b.lab.internal", "b")
+    main.flush_pending_changes()
+
+    assert nameserver.flush_applies == 0
+    assert main.PENDING_CHANGES == 1
+
+
+def test_max_wait_forces_a_flush_when_events_keep_arriving(monkeypatch):
+    """Continuous churn under the quiet threshold must not starve the apply forever."""
+    main, _fake_client = load_main(monkeypatch)
+    nameserver = RecordingNameserver()
+    main.NAMESERVER = nameserver
+    monkeypatch.setattr(main, "APPLY_QUIET_SECONDS", 3600.0)
+    monkeypatch.setattr(main, "APPLY_MAX_WAIT_SECONDS", 0.0)
+
+    main.process_start_event("caddy.lab.internal", "a.lab.internal", "a")
+    main.process_start_event("caddy.lab.internal", "b.lab.internal", "b")
+    main.flush_pending_changes()
+
+    assert nameserver.flush_applies == 1
+    assert main.PENDING_CHANGES == 0
+
+
+def test_flush_is_a_noop_when_nothing_is_pending(monkeypatch):
+    main, _fake_client = load_main(monkeypatch)
+    nameserver = RecordingNameserver()
+    main.NAMESERVER = nameserver
+
+    main.flush_pending_changes()
+    main.flush_pending_changes(force=True)
+
+    assert nameserver.flush_applies == 0
+
+
+def test_shutdown_flushes_pending_changes(monkeypatch):
+    main, fake_client = load_main(monkeypatch)
+    nameserver = RecordingNameserver()
+    main.NAMESERVER = nameserver
+    monkeypatch.setattr(main, "APPLY_QUIET_SECONDS", 3600.0)
+    monkeypatch.setattr(main, "APPLY_MAX_WAIT_SECONDS", 3600.0)
+
+    main.process_start_event("caddy.lab.internal", "a.lab.internal", "a")
+    main.process_start_event("caddy.lab.internal", "b.lab.internal", "b")
+    assert main.PENDING_CHANGES == 1
+
+    try:
+        main.cleanup(15, None)
+    except SystemExit as exc:
+        assert exc.code == 0
+    else:
+        raise AssertionError("cleanup did not exit")
+
+    # Staged changes must not be abandoned on SIGTERM.
+    assert nameserver.flush_applies == 1
+    assert fake_client.closed is True
+
+
+def test_shutdown_before_nameserver_exists_does_not_crash(monkeypatch):
+    main, fake_client = load_main(monkeypatch)
+    main.NAMESERVER = None
+
+    try:
+        main.cleanup(15, None)
+    except SystemExit as exc:
+        assert exc.code == 0
+    else:
+        raise AssertionError("cleanup did not exit")
+
+    assert fake_client.closed is True
+
+
+def test_failed_flush_reports_changes_remain_staged(monkeypatch, caplog):
+    main, _fake_client = load_main(monkeypatch)
+    nameserver = RecordingNameserver(apply_result=False)
+    main.NAMESERVER = nameserver
+    # Stage under a long quiet window, then collapse it so the flush is due.
+    monkeypatch.setattr(main, "APPLY_QUIET_SECONDS", 3600.0)
+    main.process_start_event("caddy.lab.internal", "a.lab.internal", "a")
+    main.process_start_event("caddy.lab.internal", "b.lab.internal", "b")
+    assert main.PENDING_CHANGES == 1
+    monkeypatch.setattr(main, "APPLY_QUIET_SECONDS", 0.0)
+
+    with caplog.at_level(logging.ERROR):
+        main.flush_pending_changes()
+
+    assert "staged in the pfSense configuration" in caplog.text
+    assert main.PENDING_CHANGES == 0
+
+
+def test_iter_events_yields_a_tick_after_each_window(monkeypatch):
+    main, fake_client = load_main(monkeypatch)
+    windows = []
+
+    def fake_events(since=None, until=None, decode=True):
+        assert decode is True
+        windows.append((since, until))
+        return iter([{"Type": "container", "Action": "start", "n": len(windows)}])
+
+    fake_client.events = fake_events
+
+    events = main.iter_events()
+    collected = [next(events) for _ in range(4)]
+
+    assert collected[0]["n"] == 1
+    assert collected[1] is None
+    assert collected[2]["n"] == 2
+    assert collected[3] is None
+    # Windows must be contiguous so events between them are not dropped.
+    assert windows[1][0] == windows[0][1]
+
+
+# --- Coalescing configuration -------------------------------------------------
+
+
+def test_quiet_window_is_configurable(monkeypatch):
+    monkeypatch.setenv("APPLY_QUIET_SECONDS", "2.5")
+    monkeypatch.setenv("APPLY_MAX_WAIT_SECONDS", "30")
+    main, _fake_client = load_main(monkeypatch)
+
+    assert main.APPLY_QUIET_SECONDS == 2.5
+    assert main.APPLY_MAX_WAIT_SECONDS == 30.0
+
+
+def test_unusable_coalescing_config_falls_back_to_defaults(monkeypatch, caplog):
+    main, _fake_client = load_main(monkeypatch)
+
+    with caplog.at_level(logging.WARNING):
+        assert main.get_positive_float_env("SOME_WINDOW", 10.0) == 10.0
+
+        monkeypatch.setenv("SOME_WINDOW", "not-a-number")
+        assert main.get_positive_float_env("SOME_WINDOW", 10.0) == 10.0
+
+        monkeypatch.setenv("SOME_WINDOW", "0")
+        assert main.get_positive_float_env("SOME_WINDOW", 10.0) == 10.0
+
+        monkeypatch.setenv("SOME_WINDOW", "-5")
+        assert main.get_positive_float_env("SOME_WINDOW", 10.0) == 10.0
+
+    assert "invalid" in caplog.text
+    assert "non-positive" in caplog.text
+
+
+def test_shutdown_survives_a_failing_flush(monkeypatch, caplog):
+    main, fake_client = load_main(monkeypatch)
+
+    def exploding_apply():
+        raise RuntimeError("apply blew up")
+
+    main.NAMESERVER = types.SimpleNamespace(apply_changes=exploding_apply)
+    monkeypatch.setattr(main, "PENDING_CHANGES", 1)
+    monkeypatch.setattr(main, "LAST_CHANGE_AT", 0.0)
+    monkeypatch.setattr(main, "PENDING_SINCE", 0.0)
+
+    with caplog.at_level(logging.ERROR):
+        try:
+            main.cleanup(15, None)
+        except SystemExit as exc:
+            assert exc.code == 0
+        else:
+            raise AssertionError("cleanup did not exit")
+
+    # A broken flush must not block shutdown or leave the client open.
+    assert "cleanup" in caplog.text
+    assert fake_client.closed is True
+
+
+def test_a_failed_add_stages_nothing(monkeypatch):
+    main, _fake_client = load_main(monkeypatch)
+    applies = []
+    main.NAMESERVER = types.SimpleNamespace(
+        add_host_override_alias=lambda *_args, **_kwargs: False,
+        del_host_override_alias=lambda *_args, **_kwargs: False,
+        apply_changes=lambda: applies.append("apply") or True,
+    )
+    monkeypatch.setattr(main, "APPLY_QUIET_SECONDS", 3600.0)
+    monkeypatch.setattr(main, "LAST_APPLY_AT", time.monotonic())
+
+    main.process_start_event("caddy.lab.internal", "a.lab.internal", "a")
+    main.process_stop_event("caddy.lab.internal", "b.lab.internal")
+
+    assert main.PENDING_CHANGES == 0
+    assert applies == []
+
+
+def test_a_coalesced_removal_is_staged_like_an_addition(monkeypatch):
+    main, _fake_client = load_main(monkeypatch)
+    nameserver = RecordingNameserver()
+    main.NAMESERVER = nameserver
+    monkeypatch.setattr(main, "APPLY_QUIET_SECONDS", 3600.0)
+    monkeypatch.setattr(main, "LAST_APPLY_AT", time.monotonic())
+
+    main.process_stop_event("caddy.lab.internal", "gone.lab.internal")
+
+    assert nameserver.staged == [("gone.lab.internal", False)]
+    assert main.PENDING_CHANGES == 1


### PR DESCRIPTION
Follow-up to #9. That fixed the startup scan; this fixes the path that hits far more often — a `docker compose up` of twenty labeled services fired twenty events and **twenty DNS resolver reloads**.

## Leading edge, so latency doesn't regress

A pure "10s of quiet, then apply" debounce would have made every change wait 10s, including a single container start that applies in ~2s today. Instead:

- The **first** change after a quiet period applies **immediately** — a lone container start is exactly as fast as before.
- Everything in the burst that follows is staged with `apply=False` and flushed by one `apply_changes()`.

`APPLY_QUIET_SECONDS` (default 10) is the quiet window; `APPLY_MAX_WAIT_SECONDS` (default 60) caps the wait so continuous churn can't starve the apply indefinitely. Both env-configurable, documented in the README.

**Measured against real Docker events, not stubs** — a live 20-container burst driven through the actual event loop:

| | Before | After |
|---|---|---|
| container events | 20 | 20 |
| **DNS resolver reloads** | **20** | **2** (1 immediate + 1 coalesced) |

## Single-threaded, deliberately

Flushing requires the loop to regain control periodically, but `client.events()` blocks forever. Rather than a timer thread, **`iter_events()` streams contiguous bounded windows** using `since`/`until` and yields `None` at each boundary, so `main()` can flush on a tick.

That keeps the loop single threaded — no thread, no lock, no signal-handler reentrancy — which is what preserves the resilience contract. I verified against the live daemon that a future `until` blocks for the window, delivers mid-window events, then ends the stream cleanly.

Windows are contiguous so nothing is dropped between them. An event landing exactly on a boundary may be delivered twice, which is harmless: adding an existing alias or removing an absent one is already detected and logged rather than duplicated.

## Shutdown

`cleanup()` flushes with `force=True` before closing the client — a SIGTERM with staged changes would otherwise leave them in the config but never live. It guards on `NAMESERVER` being set, since a signal can arrive before `main()` constructs it, and swallows flush errors so a broken apply can't block shutdown. Verified: `docker stop` exits 0 with the flush path exercised.

Note Docker's default 10s stop grace can still cut a slow apply short. The changes stay staged and go live on the next apply — same semantics #9 established.

## One thing worth knowing

`LAST_APPLY_AT = 0.0` reads as *long ago* on a monotonic clock, not *just now*. That bit one of my own tests and is now called out in `AGENTS.md`, since it's an easy way to write a test that silently asserts the opposite of what it means.

## Verification

84 tests (14 new), 99.01% coverage, pylint 10.00/10, actionlint clean, both audits clean, image builds, both container smoke tests pass, SIGTERM exits 0.

**Still not exercised against a real pfSense** — the reload counts are proven, but confirming aliases land correctly after a coalesced apply needs your instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)