### PR TITLE
Stop failures from stranding changes or killing the service

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ uv pip install -r requirements.txt -r requirements-dev.txt
 
 ```bash
 .venv/bin/python -m py_compile main.py pfsense.py   # required after changing either Python file
-.venv/bin/python -m pytest                          # full suite (57 tests)
+.venv/bin/python -m pytest                          # full suite (93 tests)
 .venv/bin/python -m pytest --cov --cov-report=term-missing   # with the coverage gate
 .venv/bin/python -m pytest tests/test_main.py::test_parse_alias_labels_returns_alias_config   # single test
 .venv/bin/python -m pylint main.py pfsense.py       # must stay at 10.00/10
@@ -105,13 +105,23 @@ Coalescing state (`PENDING_CHANGES`, `PENDING_SINCE`, `LAST_CHANGE_AT`, `LAST_AP
 
 ### The event loop yields window ticks
 
-`iter_events()` replaces a single blocking `client.events()` with contiguous bounded windows (`since`/`until`, `EVENT_WINDOW_SECONDS`), yielding `None` at each boundary so `main()` can call `flush_pending_changes()`. This keeps the loop **single threaded** — no timer thread, no lock, no signal-handler reentrancy — which is why the resilience contract still holds.
+`iter_events()` replaces a single blocking `client.events()` with contiguous bounded windows (`since`/`until`, `EVENT_WINDOW_SECONDS`), yielding `None` at each boundary so `main()` can call `flush_pending_changes()`. This keeps the loop **single threaded** — no timer thread, no lock — which is why the resilience contract still holds. Note that single-threading removes thread races, not signal-handler re-entry: a SIGTERM arriving mid-flush still re-enters `flush_pending_changes()` and can issue a second apply. That is bounded and non-corrupting, but do not read "single threaded" as "reentrant-safe".
 
 Windows are contiguous, so events between them are still delivered. An event landing exactly on a boundary may be delivered twice; that is harmless because adding an existing alias or removing an absent one is already detected and logged.
 
 Tests drive `main()` by monkeypatching `main.iter_events` with a finite iterable. Do not stub `client.events` for loop tests — `iter_events` loops forever by design, so main() would never return.
 
-With `apply=False`, a `True` return means **staged in the pfSense configuration but not yet live**. Staged changes persist and go live on the next successful apply.
+With `apply=False`, a `True` return means **staged in the pfSense configuration but not yet live**. Staged changes persist and go live on the next successful apply. The log says "staged", not "added"/"removed", because an operator reading "removed" while the name still resolves is worse than no message at all.
+
+**`PFSense.unapplied_changes` is the source of truth, not the return value.** A mutation can land while its apply fails, which returns `False` even though something is now staged. `unapplied_changes` is set as soon as the mutation POST succeeds and cleared only by a confirmed apply. `main._record_change_outcome()` consults it rather than the boolean — trusting the boolean stranded those changes, because nothing was pending so nothing ever retried and the alias never went live.
+
+For the same reason, **a failed flush keeps its changes pending**. `flush_pending_changes()` calls `_defer_retry()` rather than `_record_applied()` when the apply fails, so a later tick or the shutdown flush retries. `_defer_retry()` pushes the timers out a full quiet window so a pfSense outage is not retried on every two-second window tick.
+
+### API responses are untrusted input
+
+`get_all_host_overrides()` validates the payload shape — it returns `[]` for a non-list `data` and drops non-dict entries — and every accessor uses `.get()` rather than indexing. A well-formed 200 with an unexpected body previously raised `KeyError`/`TypeError` straight out of this module, which `main()` does not catch, exiting the service instead of logging and carrying on. An API schema change must degrade to a warning, never a crash loop.
+
+`_request` catches `OSError` as well as `RequestException`. `requests` raises a **bare `OSError`** when `verify` names an unreadable CA bundle, which used to escape every public method and crash-loop the container — pushing operators toward disabling TLS verification to get the service running. `main.py` also checks `PFSENSE_CA_BUNDLE` is readable at startup and exits with a clear message, since that is a configuration error worth failing loudly on.
 
 `add_host_override_alias` first calls `find_host_name(alias_fqdn)` to reject an alias already used as a host override or alias anywhere, then resolves the parent host override — the override must already exist in pfSense; this service never creates one.
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -23,6 +23,15 @@ services:
       #
       # Uncomment to scan and add aliases for existing containers on startup
       # ADD_ALIASES_ON_STARTUP: "true"
+      #
+      # Seconds without a new container event before staged DNS changes are
+      # applied together. A burst of container starts costs one reload, not one
+      # reload per alias.
+      # APPLY_QUIET_SECONDS: "10"
+      #
+      # Upper bound on how long staged changes wait, so continuous container
+      # churn cannot delay them indefinitely.
+      # APPLY_MAX_WAIT_SECONDS: "60"
       
     volumes:
       # Mount the Docker socket for listening to container events

--- a/main.py
+++ b/main.py
@@ -62,6 +62,15 @@ PFSENSE_HOSTNAME = get_env_var("PFSENSE_HOSTNAME")
 PFSENSE_API_TOKEN = get_env_var("PFSENSE_API_TOKEN")
 PFSENSE_VERIFY_SSL = os.getenv("PFSENSE_VERIFY_SSL", "true").lower() != "false"
 PFSENSE_CA_BUNDLE = os.getenv("PFSENSE_CA_BUNDLE")
+if PFSENSE_CA_BUNDLE and not os.access(PFSENSE_CA_BUNDLE, os.R_OK):
+    # Fail loudly at startup rather than on every request. An unreadable bundle used to
+    # surface as an opaque crash loop, which nudged operators toward disabling TLS
+    # verification instead of fixing the mount.
+    logger.critical(
+        f"PFSENSE_CA_BUNDLE '{PFSENSE_CA_BUNDLE}' is not readable. "
+        "Check that the CA bundle is mounted into the container at that path."
+    )
+    sys.exit(1)
 ADD_ALIASES_ON_STARTUP = os.getenv("ADD_ALIASES_ON_STARTUP", "false").lower() == "true"
 # Coalescing: a burst of container events (a compose up) should cost one reload, not
 # one per container. The first change in a quiet period still applies immediately so a
@@ -261,6 +270,12 @@ def _record_applied():
     LAST_CHANGE_AT = None
     LAST_APPLY_AT = time.monotonic()
 
+def _defer_retry():
+    """Push the next flush attempt out a full quiet window after a failed apply."""
+    global PENDING_SINCE, LAST_CHANGE_AT  # pylint: disable=global-statement
+    LAST_CHANGE_AT = time.monotonic()
+    PENDING_SINCE = LAST_CHANGE_AT
+
 def _flush_reason(force):
     """Describe why a flush is due, or None when it is not yet time."""
     if force:
@@ -285,38 +300,48 @@ def flush_pending_changes(force=False):
 
     count = PENDING_CHANGES
     logger.info(f"Applying {count} coalesced change(s) after {reason}...")
-    applied = NAMESERVER.apply_changes()
-    _record_applied()
+    if NAMESERVER.apply_changes():
+        _record_applied()
+        return
 
-    if not applied:
-        logger.error(
-            f"{count} change(s) are staged in the pfSense configuration but were not "
-            "applied. They will take effect on the next successful apply."
-        )
+    # Keep the changes pending so a later tick or the shutdown flush retries them —
+    # clearing the count here discarded them permanently. Push the next attempt out by
+    # a full quiet window so a pfSense outage is not retried on every window tick.
+    _defer_retry()
+    logger.error(
+        f"{count} change(s) remain staged in the pfSense configuration and are not live. "
+        "Retrying after the quiet period."
+    )
+
+def _record_change_outcome(succeeded):
+    """
+    Update coalescing state from what pfSense actually holds, not from the return value
+    alone.
+
+    A mutation can land in the configuration while its apply fails, which returns False
+    even though something is now staged. Trusting the boolean stranded those changes:
+    nothing was pending, so nothing ever retried the apply and the alias never went live.
+    """
+    if NAMESERVER.unapplied_changes:
+        _record_staged()
+    elif succeeded:
+        _record_applied()
 
 def process_start_event(host_override_fqdn, alias_fqdn, alias_descr):
     """Process a container start event and add an alias if necessary."""
     immediate = should_apply_immediately()
-    if not NAMESERVER.add_host_override_alias(
-        host_override_fqdn, alias_fqdn, alias_descr, apply=immediate
-    ):
-        return
-
-    if immediate:
-        _record_applied()
-    else:
-        _record_staged()
+    _record_change_outcome(
+        NAMESERVER.add_host_override_alias(
+            host_override_fqdn, alias_fqdn, alias_descr, apply=immediate
+        )
+    )
 
 def process_stop_event(host_override_fqdn, alias_fqdn):
     """Process a container stop event and remove an alias if necessary."""
     immediate = should_apply_immediately()
-    if not NAMESERVER.del_host_override_alias(host_override_fqdn, alias_fqdn, apply=immediate):
-        return
-
-    if immediate:
-        _record_applied()
-    else:
-        _record_staged()
+    _record_change_outcome(
+        NAMESERVER.del_host_override_alias(host_override_fqdn, alias_fqdn, apply=immediate)
+    )
 
 NAMESERVER = None
 

--- a/pfsense.py
+++ b/pfsense.py
@@ -77,6 +77,10 @@ class PFSense:
         self.pfsense_host = pfsense_host
         self.pfsense_api_key = pfsense_api_key
         self.verify_ssl = ca_bundle if ca_bundle else verify_ssl
+        # True whenever a mutation has landed in the pfSense configuration but has not
+        # been confirmed applied. Callers use it to keep retrying rather than assuming a
+        # False return meant nothing happened.
+        self.unapplied_changes = False
         if self.verify_ssl is False:
             urllib3.disable_warnings(InsecureRequestWarning)
         logger.info(f"pfSense host set to {self.pfsense_host}")
@@ -108,7 +112,10 @@ class PFSense:
         for attempt in range(1, attempts + 1):
             try:
                 return method(**kwargs)
-            except requests.RequestException as e:
+            # OSError, not just RequestException: requests raises a bare OSError when
+            # `verify` names an unreadable CA bundle. Letting that escape crash-looped
+            # the container, which pushed operators toward disabling verification.
+            except (requests.RequestException, OSError) as e:
                 if attempt == attempts:
                     self._handle_api_error(e, context)
                     return None
@@ -163,6 +170,7 @@ class PFSense:
         for attempt in range(1, APPLY_POLL_ATTEMPTS + 1):
             if self._changes_applied():
                 logger.info("DNS resolver changes applied.")
+                self.unapplied_changes = False
                 return True
 
             if attempt < APPLY_POLL_ATTEMPTS:
@@ -226,10 +234,19 @@ class PFSense:
             if response is None:
                 return []
             response.raise_for_status()
-            return response.json().get('data', [])
-        except (requests.RequestException, ValueError) as e:
+            data = response.json().get('data', [])
+        except (requests.RequestException, OSError, ValueError, AttributeError) as e:
             self._handle_api_error(e, "get_all_host_overrides")
             return []
+
+        # Validate the shape here so callers can index safely. An API schema change or
+        # a partial object previously raised KeyError/TypeError straight out of this
+        # module, which exits the service instead of logging and carrying on.
+        if not isinstance(data, list):
+            logger.error("Unexpected host override payload; expected a list.")
+            return []
+
+        return [entry for entry in data if isinstance(entry, dict)]
 
     def find_host_name(self, fqdn):
         """
@@ -244,7 +261,7 @@ class PFSense:
         host, domain = split_fqdn
         host_overrides = self.get_all_host_overrides()
         for host_override in host_overrides:
-            if host_override['host'] == host and host_override['domain'] == domain:
+            if host_override.get('host') == host and host_override.get('domain') == domain:
                 return host_override
             if self.find_alias_in_host_override(host_override, fqdn) is not None:
                 return host_override
@@ -263,16 +280,19 @@ class PFSense:
 
         alias_host, alias_domain = split_fqdn
 
-        alias = None
-        if 'aliases' in host_override and host_override['aliases']:
-            alias = next(
-                (
-                    al for al in host_override['aliases']
-                    if al['host'] == alias_host and al['domain'] == alias_domain
-                ),
-                None
-            )
-        return alias
+        aliases = host_override.get('aliases') or []
+        if not isinstance(aliases, list):
+            return None
+
+        return next(
+            (
+                al for al in aliases
+                if isinstance(al, dict)
+                and al.get('host') == alias_host
+                and al.get('domain') == alias_domain
+            ),
+            None
+        )
 
     def add_host_override_alias(self, host_override_fqdn, alias_fqdn, alias_descr="", apply=True):
         # pylint: disable=too-many-return-statements,redefined-builtin
@@ -306,8 +326,13 @@ class PFSense:
             logger.warning(f"Host override {host_override_fqdn} not found.")
             return False
 
+        parent_id = host_override.get("id")
+        if parent_id is None:
+            logger.error(f"Host override {host_override_fqdn} has no id; cannot add alias.")
+            return False
+
         data = {
-            'parent_id': f'{host_override["id"]}',
+            'parent_id': f'{parent_id}',
             'host': f'{alias_host}',
             'domain': f'{alias_domain}',
             'descr': f'{alias_descr}'
@@ -327,18 +352,26 @@ class PFSense:
                 return False
             response.raise_for_status()
 
-        except requests.RequestException as e:
+        except (requests.RequestException, OSError) as e:
             self._handle_api_error(e, "add_host_override_alias")
             return False
 
-        if apply and not self.apply_changes():
-            return False
+        # The alias now exists in the pfSense configuration whether or not the apply
+        # below succeeds. Recording that is what stops a failed apply from stranding
+        # the change with nothing tracking it.
+        self.unapplied_changes = True
 
-        logger.info(f"Alias {alias_fqdn} added to host override {host_override_fqdn}.")
+        if apply:
+            if not self.apply_changes():
+                return False
+            logger.info(f"Alias {alias_fqdn} added to host override {host_override_fqdn}.")
+        else:
+            logger.info(f"Alias {alias_fqdn} staged for host override {host_override_fqdn}.")
+
         return True
 
     def del_host_override_alias(self, host_override_fqdn, alias_fqdn, apply=True):
-        # pylint: disable=redefined-builtin
+        # pylint: disable=redefined-builtin,too-many-return-statements
         """
         Removes an alias from an existing host override in pfSense.
 
@@ -359,9 +392,15 @@ class PFSense:
             logger.warning(f"Alias {alias_fqdn} not found in host override {host_override_fqdn}.")
             return False
 
+        parent_id = alias.get("parent_id")
+        alias_id = alias.get("id")
+        if parent_id is None or alias_id is None:
+            logger.error(f"Alias {alias_fqdn} is missing an id; cannot remove it.")
+            return False
+
         data = {
-            'parent_id': f'{alias["parent_id"]}',
-            'id': f'{alias["id"]}',
+            'parent_id': f'{parent_id}',
+            'id': f'{alias_id}',
         }
 
         try:
@@ -379,12 +418,17 @@ class PFSense:
                 return False
             response.raise_for_status()
 
-        except requests.RequestException as e:
+        except (requests.RequestException, OSError) as e:
             self._handle_api_error(e, "del_host_override_alias")
             return False
 
-        if apply and not self.apply_changes():
-            return False
+        self.unapplied_changes = True
 
-        logger.info(f"Alias {alias_fqdn} removed from host override {host_override_fqdn}.")
+        if apply:
+            if not self.apply_changes():
+                return False
+            logger.info(f"Alias {alias_fqdn} removed from host override {host_override_fqdn}.")
+        else:
+            logger.info(f"Alias {alias_fqdn} staged for removal from {host_override_fqdn}.")
+
         return True

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -557,6 +557,7 @@ def test_process_events_delegate_to_nameserver(monkeypatch):
     added = []
     removed = []
     main.NAMESERVER = types.SimpleNamespace(
+        unapplied_changes=False,
         add_host_override_alias=lambda host, alias, descr, apply: added.append(
             (host, alias, descr, apply)
         )
@@ -613,12 +614,21 @@ def _labeled_container(name, alias):
 
 
 def _recording_nameserver(staged, applies, add_result=True, apply_result=True):
-    return types.SimpleNamespace(
-        add_host_override_alias=lambda host_override, alias, description, apply: (
-            staged.append((alias, apply)) or add_result
-        ),
-        apply_changes=lambda: applies.append("apply") or apply_result,
-    )
+    nameserver = RecordingNameserver(apply_result=apply_result, mutation_result=add_result)
+    real_add = nameserver.add_host_override_alias
+    real_apply = nameserver.apply_changes
+
+    def add(host_override, alias, description, apply):
+        staged.append((alias, apply))
+        return real_add(host_override, alias, description, apply)
+
+    def apply_changes():
+        applies.append("apply")
+        return real_apply()
+
+    nameserver.add_host_override_alias = add
+    nameserver.apply_changes = apply_changes
+    return nameserver
 
 
 def test_startup_scan_applies_once_for_many_aliases(monkeypatch):
@@ -696,29 +706,50 @@ def test_startup_scan_reports_staged_aliases_when_the_apply_fails(monkeypatch, c
 
 
 class RecordingNameserver:
-    """Counts applies, distinguishing immediate ones from coalesced flushes."""
+    """
+    Counts applies, distinguishing immediate ones from coalesced flushes.
 
-    def __init__(self, apply_result=True):
+    Mirrors the real PFSense contract: a mutation that lands sets unapplied_changes,
+    and only a confirmed apply clears it. Modelling that is what lets these tests catch
+    a change that stages successfully but fails to apply.
+    """
+
+    def __init__(self, apply_result=True, mutation_result=True):
         self.staged = []
         self.immediate_applies = 0
         self.flush_applies = 0
         self.apply_result = apply_result
+        self.mutation_result = mutation_result
+        self.unapplied_changes = False
+
+    def _mutate(self, alias, apply):
+        self.staged.append((alias, apply))
+        if not self.mutation_result:
+            return False
+
+        self.unapplied_changes = True
+        if not apply:
+            return True
+
+        self.immediate_applies += 1
+        if not self.apply_result:
+            return False
+
+        self.unapplied_changes = False
+        return True
 
     def add_host_override_alias(self, _host_override, alias, _descr, apply):
-        self.staged.append((alias, apply))
-        if apply:
-            self.immediate_applies += 1
-        return True
+        return self._mutate(alias, apply)
 
     def del_host_override_alias(self, _host_override, alias, apply):
-        self.staged.append((alias, apply))
-        if apply:
-            self.immediate_applies += 1
-        return True
+        return self._mutate(alias, apply)
 
     def apply_changes(self):
         self.flush_applies += 1
-        return self.apply_result
+        if not self.apply_result:
+            return False
+        self.unapplied_changes = False
+        return True
 
     @property
     def total_applies(self):
@@ -839,22 +870,82 @@ def test_shutdown_before_nameserver_exists_does_not_crash(monkeypatch):
     assert fake_client.closed is True
 
 
-def test_failed_flush_reports_changes_remain_staged(monkeypatch, caplog):
+def test_a_failed_flush_keeps_changes_pending_for_retry(monkeypatch, caplog):
+    """
+    A failed apply must not discard the pending count.
+
+    Clearing it stranded the changes: the shutdown flush had nothing left to retry, so
+    aliases sat in the pfSense configuration and never went live.
+    """
     main, _fake_client = load_main(monkeypatch)
     nameserver = RecordingNameserver(apply_result=False)
     main.NAMESERVER = nameserver
-    # Stage under a long quiet window, then collapse it so the flush is due.
     monkeypatch.setattr(main, "APPLY_QUIET_SECONDS", 3600.0)
+
     main.process_start_event("caddy.lab.internal", "a.lab.internal", "a")
     main.process_start_event("caddy.lab.internal", "b.lab.internal", "b")
-    assert main.PENDING_CHANGES == 1
-    monkeypatch.setattr(main, "APPLY_QUIET_SECONDS", 0.0)
+    # Both are pending: the first because its immediate apply failed, the second
+    # because it was coalesced behind it.
+    assert main.PENDING_CHANGES == 2
 
+    monkeypatch.setattr(main, "APPLY_QUIET_SECONDS", 0.0)
     with caplog.at_level(logging.ERROR):
         main.flush_pending_changes()
 
-    assert "staged in the pfSense configuration" in caplog.text
+    assert "remain staged" in caplog.text
+    assert main.PENDING_CHANGES == 2
+
+    # And they are still there for the shutdown flush to retry.
+    nameserver.apply_result = True
+    main.flush_pending_changes(force=True)
     assert main.PENDING_CHANGES == 0
+    assert nameserver.unapplied_changes is False
+
+
+def test_a_stranded_change_is_retried_rather_than_lost(monkeypatch):
+    """
+    A mutation that lands but fails to apply must stay tracked.
+
+    The mutator returns False in that case, which previously read as "nothing happened",
+    so nothing was pending and the alias never went live.
+    """
+    main, _fake_client = load_main(monkeypatch)
+    nameserver = RecordingNameserver(apply_result=False)
+    main.NAMESERVER = nameserver
+
+    main.process_start_event("caddy.lab.internal", "svc.lab.internal", "svc")
+
+    # The create landed even though the apply did not confirm.
+    assert nameserver.unapplied_changes is True
+    assert main.PENDING_CHANGES == 1
+
+    # pfSense recovers; shutdown flushes the stranded change.
+    nameserver.apply_result = True
+    main.flush_pending_changes(force=True)
+
+    assert nameserver.flush_applies == 1
+    assert nameserver.unapplied_changes is False
+    assert main.PENDING_CHANGES == 0
+
+
+def test_a_failed_flush_defers_the_next_attempt(monkeypatch):
+    """A pfSense outage must not be retried on every two-second window tick."""
+    main, _fake_client = load_main(monkeypatch)
+    nameserver = RecordingNameserver(apply_result=False)
+    main.NAMESERVER = nameserver
+    monkeypatch.setattr(main, "APPLY_QUIET_SECONDS", 3600.0)
+    monkeypatch.setattr(main, "APPLY_MAX_WAIT_SECONDS", 3600.0)
+
+    main.process_start_event("caddy.lab.internal", "a.lab.internal", "a")
+    monkeypatch.setattr(main, "APPLY_QUIET_SECONDS", 0.0)
+    main.flush_pending_changes()
+    assert nameserver.flush_applies == 1
+
+    # Timers were pushed out, so an immediate second tick does not retry.
+    monkeypatch.setattr(main, "APPLY_QUIET_SECONDS", 3600.0)
+    main.flush_pending_changes()
+    assert nameserver.flush_applies == 1
+    assert main.PENDING_CHANGES == 1
 
 
 def test_iter_events_yields_a_tick_after_each_window(monkeypatch):
@@ -938,6 +1029,7 @@ def test_a_failed_add_stages_nothing(monkeypatch):
     main, _fake_client = load_main(monkeypatch)
     applies = []
     main.NAMESERVER = types.SimpleNamespace(
+        unapplied_changes=False,
         add_host_override_alias=lambda *_args, **_kwargs: False,
         del_host_override_alias=lambda *_args, **_kwargs: False,
         apply_changes=lambda: applies.append("apply") or True,

--- a/tests/test_pfsense.py
+++ b/tests/test_pfsense.py
@@ -755,3 +755,150 @@ def test_apply_changes_treats_a_malformed_status_body_as_not_applied(monkeypatch
     client = PFSense("pfsense.lab.internal", "secret-token")
 
     assert client.apply_changes() is False
+
+
+# --- Failures must log and return False, never raise --------------------------
+
+
+def test_malformed_host_override_payload_does_not_raise(monkeypatch, caplog):
+    """
+    A well-formed 200 with an unexpected body used to raise KeyError/TypeError straight
+    out of this module, which exits the service instead of logging and carrying on.
+    """
+    client = PFSense("pfsense.lab.internal", "secret-token")
+
+    for payload in (
+        {"data": [{"host": "caddy", "domain": "lab.internal"}]},   # no id
+        {"data": [{"host": "caddy"}]},                              # no domain
+        {"data": {"unexpected": "dict"}},                           # not a list
+        {"data": ["a string", 42, None]},                           # not dicts
+        {"data": [{"host": "caddy", "domain": "lab.internal", "aliases": "nope"}]},
+        {"data": [{"host": "caddy", "domain": "lab.internal", "aliases": [None, 7]}]},
+        {"nodata": True},
+    ):
+        def responder(_payload=payload, **_kwargs):
+            return FakeResponse(_payload)
+
+        monkeypatch.setattr("pfsense.requests.get", responder)
+        monkeypatch.setattr("pfsense.requests.post", lambda **_kwargs: FakeResponse())
+        monkeypatch.setattr("pfsense.requests.delete", lambda **_kwargs: FakeResponse())
+
+        with caplog.at_level(logging.WARNING):
+            # The contract is "log and return False", never raise.
+            assert client.add_host_override_alias(
+                "caddy.lab.internal", "nginx.lab.internal"
+            ) is False
+            assert client.del_host_override_alias(
+                "caddy.lab.internal", "nginx.lab.internal"
+            ) is False
+            client.find_host_name("caddy.lab.internal")
+
+
+def test_host_override_without_an_id_is_reported_not_raised(monkeypatch, caplog):
+    monkeypatch.setattr("pfsense.requests.post", lambda **_kwargs: FakeResponse())
+    client = PFSense("pfsense.lab.internal", "secret-token")
+    client.get_all_host_overrides = lambda: [
+        {"host": "caddy", "domain": "lab.internal", "aliases": []}
+    ]
+
+    with caplog.at_level(logging.ERROR):
+        assert not client.add_host_override_alias("caddy.lab.internal", "nginx.lab.internal")
+
+    assert "no id" in caplog.text
+
+
+def test_alias_without_an_id_is_reported_not_raised(monkeypatch, caplog):
+    monkeypatch.setattr("pfsense.requests.delete", lambda **_kwargs: FakeResponse())
+    client = PFSense("pfsense.lab.internal", "secret-token")
+    client.get_all_host_overrides = lambda: [
+        {
+            "id": 12,
+            "host": "caddy",
+            "domain": "lab.internal",
+            "aliases": [{"host": "nginx", "domain": "lab.internal"}],
+        }
+    ]
+
+    with caplog.at_level(logging.ERROR):
+        assert not client.del_host_override_alias("caddy.lab.internal", "nginx.lab.internal")
+
+    assert "missing an id" in caplog.text
+
+
+def test_an_unreadable_ca_bundle_does_not_escape_as_oserror(monkeypatch):
+    """
+    requests raises a bare OSError, not a RequestException, when `verify` names an
+    unreadable path. Letting it escape crash-looped the container.
+    """
+    monkeypatch.setattr("pfsense.time.sleep", lambda _seconds: None)
+
+    def missing_bundle(**_kwargs):
+        raise OSError("Could not find a suitable TLS CA certificate bundle")
+
+    monkeypatch.setattr("pfsense.requests.get", missing_bundle)
+    monkeypatch.setattr("pfsense.requests.post", missing_bundle)
+    monkeypatch.setattr("pfsense.requests.delete", missing_bundle)
+
+    client = PFSense("pfsense.lab.internal", "secret-token", ca_bundle="/missing/ca.pem")
+
+    assert client.get_all_host_overrides() == []
+    assert client.add_host_override_alias("caddy.lab.internal", "nginx.lab.internal") is False
+    assert client.del_host_override_alias("caddy.lab.internal", "nginx.lab.internal") is False
+    assert client.apply_changes() is False
+
+
+# --- Staged changes stay tracked until confirmed applied ----------------------
+
+
+def test_a_landed_mutation_marks_unapplied_changes(monkeypatch):
+    monkeypatch.setattr("pfsense.requests.post", lambda **_kwargs: FakeResponse())
+    monkeypatch.setattr("pfsense.requests.get", applied_status_get(applied=False))
+    monkeypatch.setattr("pfsense.time.sleep", lambda _seconds: None)
+
+    client = PFSense("pfsense.lab.internal", "secret-token")
+    client.get_all_host_overrides = lambda: [
+        {"id": 12, "host": "caddy", "domain": "lab.internal", "aliases": []}
+    ]
+
+    assert client.unapplied_changes is False
+    # The create lands but the apply never confirms.
+    assert client.add_host_override_alias("caddy.lab.internal", "nginx.lab.internal") is False
+    assert client.unapplied_changes is True
+
+
+def test_a_confirmed_apply_clears_unapplied_changes(monkeypatch):
+    monkeypatch.setattr("pfsense.requests.post", lambda **_kwargs: FakeResponse())
+    monkeypatch.setattr("pfsense.requests.get", applied_status_get(applied=True))
+
+    client = PFSense("pfsense.lab.internal", "secret-token")
+    client.unapplied_changes = True
+
+    assert client.apply_changes() is True
+    assert client.unapplied_changes is False
+
+
+def test_staging_logs_staged_not_added(monkeypatch, caplog):
+    """An operator reading 'removed' must not be told a name is gone while it resolves."""
+    monkeypatch.setattr("pfsense.requests.post", lambda **_kwargs: FakeResponse())
+    monkeypatch.setattr("pfsense.requests.delete", lambda **_kwargs: FakeResponse())
+
+    client = PFSense("pfsense.lab.internal", "secret-token")
+    client.get_all_host_overrides = lambda: [
+        {
+            "id": 12,
+            "host": "caddy",
+            "domain": "lab.internal",
+            "aliases": [{"id": 34, "parent_id": 12, "host": "gone", "domain": "lab.internal"}],
+        }
+    ]
+
+    with caplog.at_level(logging.INFO):
+        client.add_host_override_alias(
+            "caddy.lab.internal", "nginx.lab.internal", "n", apply=False
+        )
+        client.del_host_override_alias("caddy.lab.internal", "gone.lab.internal", apply=False)
+
+    assert "staged for host override" in caplog.text
+    assert "staged for removal" in caplog.text
+    assert "added to host override" not in caplog.text
+    assert "removed from host override" not in caplog.text


### PR DESCRIPTION
Fixes the four highest-severity findings from the whole-codebase code and security review. Common theme: **a failure should log and degrade, not silently drop a change or exit the process.**

All three reproductions from the review were re-run and no longer reproduce.

## 1. A change that stages but fails to apply was stranded forever

Both mutators return `False` when the POST succeeded but the apply didn't confirm. `process_start_event` read that as "nothing happened", so `PENDING_CHANGES` stayed 0 and nothing ever retried — the alias sat in the pfSense config and never went live. It only self-healed if another container event happened to arrive, which for the lone-start case the coalescing design specifically optimizes is exactly what doesn't happen.

`PFSense` now exposes **`unapplied_changes`**, set when a mutation POST succeeds and cleared only by a *confirmed* apply. `_record_change_outcome()` consults it instead of the boolean.

Before: `config=['svc.lab.internal'] live=[] PENDING=0` — stranded.
After: `PENDING=1`, and the shutdown flush applies it.

## 2. A failed flush discarded the pending changes

`flush_pending_changes()` called `_record_applied()` unconditionally, zeroing the count and back-dating `LAST_APPLY_AT`, so the shutdown flush had nothing to retry and the state claimed an apply had just succeeded. It now keeps the changes pending and calls `_defer_retry()`, pushing the next attempt out a full quiet window so a pfSense outage isn't retried on every 2s window tick.

A test was actively pinning the lossy behavior; it's rewritten to pin the fix.

## 3. A malformed API response killed the service

`host_override['id']` and friends indexed unvalidated API data. `main()` catches only `DockerException`, so a `KeyError` reached `run()` → `exit(1)` — a restart loop on an API schema change, and the exact opposite of the documented log-and-continue contract.

`get_all_host_overrides()` now validates the payload shape (non-list `data` → `[]`, non-dict entries dropped) and every accessor uses `.get()`, with explicit errors for a missing id.

## 4. An unreadable CA bundle crash-looped the container

`requests` raises a **bare `OSError`**, not a `RequestException`, when `verify` names an unreadable path — so it escaped every public method. `_request` now catches `OSError` too, and `main.py` checks the bundle is readable at startup and exits with an actionable message.

The security sting: the *more secure* configuration was the one that bricked the service, and the shipped compose example makes it easy to hit (the env var and its volume mount are two separate uncomments). That pressures an operator toward `PFSENSE_VERIFY_SSL=false`. Now:

```
CRITICAL - PFSENSE_CA_BUNDLE '/etc/ssl/certs/missing-ca.pem' is not readable.
Check that the CA bundle is mounted into the container at that path.
```

## Also

- Staged mutations log **"staged"**, not "added"/"removed". Telling an operator a name was removed while it still resolves is worse than saying nothing.
- **A correction:** `AGENTS.md` claimed the design has "no signal-handler reentrancy". That's wrong — single-threading removes thread races, not handler re-entry, and a SIGTERM mid-flush can still issue a second apply. Documented accurately now.
- Test count and `docker-compose.yaml` env vars brought back in sync.

## Verification

93 tests (+9), 98.88% coverage, pylint 10.00/10, actionlint clean, both audits clean, compose valid, image builds, both smoke tests pass, and an unreadable bundle exits 1 with a clear message instead of an opaque loop.

## Still open from the review

Lower-severity, deliberately not in this PR: log forgery via newlines in container labels, the status-poll `verify=` test gap (mutation-provable), `get_all_host_overrides` not using `_headers()`, `alias_descr` bypassing `_split_fqdn`, `bool("false") == True` failing open, and CI's unpinned `curl | bash` for actionlint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)