### PR TITLE
Make _headers() the single header construction point

### DIFF
--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -15,6 +15,8 @@ A daemon holding a pfSense API token, mounting `/var/run/docker.sock`, and turni
 
 It authenticates DNS changes on a firewall. It must never reach logs, error messages, exception text, or CI output. `_handle_api_error` deliberately logs the exception and status code but **not** `response.text`, and `test_http_error_logs_status_without_response_body` pins that. Any new error path, debug line, or re-raise that widens what gets logged is a finding. So is anything that puts the token in a URL rather than the `X-API-Key` header.
 
+`PFSense._headers()` is the single construction point for those headers, and `X-API-Key` should appear exactly once in `pfsense.py` — inside it. A request that builds the header dict inline is a finding even when it is byte-identical today, because it silently opts out of any future hardening of `_headers()`. `grep -c X-API-Key pfsense.py` is the check.
+
 ### 2. TLS trust
 
 `PFSENSE_VERIFY_SSL` is fail-secure: true unless the value lowercases to exactly `"false"`. `PFSENSE_CA_BUNDLE` takes precedence and is passed straight to `requests`' `verify=`. Treat as findings: any change making verification easier to disable, any default flip, any broadening of what counts as "false", and any call path that forgets to pass `verify=` at all.

--- a/pfsense.py
+++ b/pfsense.py
@@ -307,18 +307,13 @@ class PFSense:
 
     def get_all_host_overrides(self):
         """Returns all the host overrides defined in pfSense"""
-        # Define the headers for authentication
-        headers = {
-            'X-API-Key': f"{self.pfsense_api_key}",
-            'Content-Type': 'application/json'
-        }
         # Fetch existing host overrides to find the one to update
         try:
             response = self._request(
                 requests.get,
                 "get_all_host_overrides",
                 url=f'https://{self.pfsense_host}/api/v2/services/dns_resolver/host_overrides',
-                headers=headers,
+                headers=self._headers(),
                 verify=self.verify_ssl,
                 timeout=10
             )


### PR DESCRIPTION
Closes the last of the four minor findings from the 2026-08-02 whole-codebase review.

`get_all_host_overrides` built the `X-API-Key` dict inline instead of calling `self._headers()`. Byte-identical today, so there was never any exposure — but it defeated the extraction, and a future hardening of `_headers()` would have silently skipped the most-called method in the class.

`X-API-Key` now appears exactly once in `pfsense.py`, inside `_headers()`. `.claude/agents/security-reviewer.md` records that as the invariant next to the existing token rules, with `grep -c X-API-Key pfsense.py` as the check — an inline header dict is a finding even when it is byte-identical, because it opts out of any future hardening.

## Why this is safe

Pure substitution, no behavior change. `test_get_all_host_overrides_constructs_request` already asserted the exact header dict — `{"X-API-Key": "secret-token", "Content-Type": "application/json"}` — as part of a whole-call-list equality on url, headers, verify, and timeout. It passes unmodified, which is precisely the point: the existing test proves the two constructions were identical, so replacing one with the other cannot change what goes on the wire.

No test changes. Net −3 lines.

## Verification

133 tests pass, pylint 10.00/10, coverage 98.93% against the 80% gate, `pip-audit --strict` clean, `docker build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)