### PR TITLE
Pin actionlint instead of piping an install script into bash

### DIFF
--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -43,6 +43,10 @@ When reviewing any change to the payload barrier's helpers and their constants (
 
 Mounting `/var/run/docker.sock` grants effective root on the host. This is accepted and documented, but changes that widen it are findings: writing through the socket rather than reading events, running the container with added privileges, or the CI smoke test's socket mount migrating to a self-hosted runner where the host is persistent and shared rather than ephemeral.
 
+### 5. What CI executes
+
+The `test` job runs on `pull_request`, so anything it fetches and runs is reachable by a branch, from a fork. Executable third-party content must be pinned to an immutable reference: actionlint arrives as a version-pinned release asset checked against `ACTIONLINT_SHA256` before it is unpacked. Reintroducing a `curl … | bash`, pointing a download at a branch or at `latest`, or relaxing the checksum verification to make a bump pass is a finding — `grep -n 'curl' .github/workflows/*.yml` should turn up no pipe into a shell. Actions pinned to mutable major tags (`@v7`, `@v4`) are an accepted trade-off because Dependabot tracks and bumps them; the actionlint pin is *not* tracked, so check that a version bump moved the hash with it.
+
 ## How to review
 
 Start from the diff. For dependency changes, check the advisory status of what is being added or bumped and read release notes for major versions — a green CI check does **not** validate an action used only in the tag-gated `build-and-push` job, which never runs on a PR.

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -29,10 +29,25 @@ jobs:
           python -m pip install -r requirements.txt
           python -m pip install -r requirements-dev.txt
 
+      # Installed from a pinned release asset with a checksum rather than by
+      # piping actionlint's install script into bash. That script is fetched
+      # from a branch we do not control and resolves `latest` at run time, so
+      # a compromise upstream would run arbitrary code in this job — which
+      # runs on `pull_request`. Dependabot does not track this pin: bump
+      # ACTIONLINT_VERSION and ACTIONLINT_SHA256 together by hand, taking the
+      # hash from the actionlint_<version>_checksums.txt published with the
+      # release.
       - name: Lint workflows
+        env:
+          ACTIONLINT_VERSION: 1.7.12
+          ACTIONLINT_SHA256: 8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
         run: |
-          curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash \
-            | bash -s -- latest "${RUNNER_TEMP}"
+          set -euo pipefail
+          archive="${RUNNER_TEMP}/actionlint.tar.gz"
+          curl -sSfL -o "${archive}" \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          echo "${ACTIONLINT_SHA256}  ${archive}" | sha256sum -c -
+          tar -xzf "${archive}" -C "${RUNNER_TEMP}" actionlint
           "${RUNNER_TEMP}/actionlint" -color
 
       - name: Compile Python files

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,8 @@ Coverage config lives in `.coveragerc` rather than `pyproject.toml` on purpose �
 
 `actionlint` checks the workflow files and is not a pip package — download it when you need it. It shells out to `shellcheck` for `run:` blocks **only if shellcheck is on `PATH`**, and GitHub runners have it while a plain dev box usually does not. Local actionlint without shellcheck is therefore weaker than CI and will miss shell issues that fail the build; install shellcheck before trusting a local pass.
 
+CI installs it from a **pinned release asset verified against a SHA256**, not by piping upstream's install script into bash — that script is fetched from a branch we do not control and resolves `latest` at run time, and the job it runs in is triggered by `pull_request`. Dependabot does not track this pin, so it is the one version in this repo that drifts silently: bump `ACTIONLINT_VERSION` and `ACTIONLINT_SHA256` in `.github/workflows/docker-publish.yml` together, taking the hash for `linux_amd64` from the `actionlint_<version>_checksums.txt` published with the release. A version bump without a matching hash fails the `sha256sum -c` step, which is the intended failure — never drop the checksum to get past it.
+
 `pip-audit` runs `--strict` against both requirements files, so a newly disclosed CVE in a pinned dependency turns CI red without any code change. That is intended: this service ships TLS calls and an API token, and `certifi` *is* its trust store. Fix by bumping the pin, not by ignoring the finding. Dependabot (`.github/dependabot.yml`) opens weekly PRs for pip, GitHub Actions, and the base image to keep that from accumulating.
 
 ### Manual end-to-end check


### PR DESCRIPTION
Closes the last open finding from the 2026-08-02 whole-codebase review.

The `Lint workflows` step curled actionlint's install script from that repository's `main` branch and piped it into `bash`, passing `latest` as the version. Both references are mutable, so a compromise upstream would have run arbitrary code in the `test` job — which runs on `pull_request`, and so is reachable from a fork branch. Blast radius was small (`contents: read`, no secrets), but the step executed code nobody here had pinned or reviewed.

The step now downloads a version-pinned release asset and verifies it against `ACTIONLINT_SHA256` before unpacking, so a swapped artifact fails the build rather than executing.

## Verification

Ran the new step verbatim in a scratch `RUNNER_TEMP`, with shellcheck on `PATH` so the local pass is as strong as CI's:

- as written — installs actionlint 1.7.12, checksum `OK`, lints the workflow clean, exit 0.
- with a deliberately corrupted expected hash — aborts at `sha256sum -c` with `FAILED`, exit 1, and no binary extracted. The guard fails closed.

Also `pytest` 133 passed and `pylint` 10.00/10, unchanged — no Python was touched. `docker build` was not run: nothing this change touches is copied into the image.

## What I deliberately did not do

**Dependabot does not track this pin.** That is the real cost of the fix, and it is a downgrade in one respect: the version used to float forward on its own, and now it will silently go stale. I judged an unreviewed-code-execution path worse than a lagging linter, but it is a trade, not a free win. `AGENTS.md` and `.claude/agents/security-reviewer.md` both record that `ACTIONLINT_VERSION` and `ACTIONLINT_SHA256` are bumped together by hand, and that relaxing the checksum to get a bump through is itself a finding.

**Actions are still on mutable major tags** (`@v7`, `@v4`) rather than commit SHAs. Dependabot does track those and opens weekly PRs, so they carry a review step this curl did not. Left alone deliberately; pinning them to SHAs is a separate decision about whether that trade is worth losing readable version numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)