### PR TITLE
Add CONTRIBUTING.md and a scripted local end-to-end test environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,6 @@
 README.md
+CONTRIBUTING.md
+test-env/
 LICENSE
 .git/
 .dockerignore

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,14 @@ docker rm -f pfsense-alias-smoke smoke-nginx
 
 Expect start/stop to be detected, three retries per API call, an error log, and the service to **stay running** — that resilience is the contract, so a crash here is a regression.
 
+### The real end-to-end check, against a real pfSense
+
+`test-env/bootstrap.sh` builds a throwaway pfSense VM with the REST API package installed (about ten minutes and 6 GB of disk, entirely outside the working tree), and `test-env/smoke.sh` runs the service against it and asserts the whole path: alias created, resolving through the firewall's own resolver, removed on stop, service still alive. `test-env/vm.sh reset` rolls back to a clean snapshot in about a second. `test-env/README.md` is the reference; `CONTRIBUTING.md` says when to reach for it.
+
+This needs KVM, so it cannot run on GitHub's runners and is not part of CI. Run it by hand for any change touching `pfsense.py`, the apply/coalescing logic, or what goes into an API payload. The unit suite stubs both Docker and the API, so it can only confirm the client matches *our own idea* of the API — it cannot tell you whether a field lands where pfSense reads it, or whether a name resolves afterwards. Both of those questions have already been settled here in ways the suite could not have reached: the alias description really does arrive (the API's `descr` is written to `config.xml` as `description`, which is the key the webGUI renders), and `--rm` containers can lose their alias removal entirely, because the stop handler reads labels back from a container Docker has already deleted.
+
+Two things about that environment are worth knowing before using it. Every request from the host reaches pfSense from one address, so its brute-force protection can blackhole SSH, the webGUI and the REST API simultaneously while the serial console still looks healthy — `bootstrap.sh` whitelists it, but suspect it first if everything goes quiet at once. And containers cannot reach the VM through QEMU's port forwarding directly; `test-env/relay.sh` bridges that gap.
+
 CI (`.github/workflows/docker-publish.yml`) runs on every PR and push to `main`: actionlint → compile → pylint → pip-audit → pytest with the coverage gate → `docker build` → two container smoke tests. The smoke tests run the built image and assert it exits 1 with a config error when unconfigured, then boots and reaches its event loop when configured. They exist because `docker build` cannot catch a runtime module missing its `COPY` — that image builds cleanly and dies at import. The ghcr.io publish job runs only on tag pushes.
 
 ## Architecture

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,136 @@
+# Contributing
+
+Thanks for helping out. This file covers how to get set up, what has to pass
+before a pull request, and how to test a change against a real pfSense.
+
+`AGENTS.md` is the deeper reference: it explains *why* the failure semantics,
+injection barriers and coalescing behave the way they do. Read it before
+changing any of them. This file does not repeat it.
+
+## Getting set up
+
+The project is two Python modules with no framework and no package layout.
+Python 3.14 matches CI and the runtime image.
+
+```bash
+uv venv --python 3.14
+uv pip install -r requirements.txt -r requirements-dev.txt
+```
+
+## Before you open a pull request
+
+Run these from the repository root. CI runs the same checks, so running them
+locally just saves a round trip.
+
+```bash
+.venv/bin/python -m py_compile main.py pfsense.py
+.venv/bin/python -m pytest --cov --cov-report=term-missing
+.venv/bin/python -m pylint main.py pfsense.py
+.venv/bin/python -m pip_audit -r requirements.txt --strict
+.venv/bin/python -m pip_audit -r requirements-dev.txt --strict
+docker build -t pfsense-docker-alias .
+```
+
+Run pytest as `python -m pytest`, not bare `pytest`. There is no `conftest.py`
+or `pyproject.toml`; `main` and `pfsense` are importable only because `python -m`
+puts the working directory on `sys.path`.
+
+A few of these fail in ways worth understanding rather than working around:
+
+- **pylint must stay at 10.00/10.** Suppress with a narrow local
+  `# pylint: disable=` pragma when genuinely warranted, never with a config file.
+- **Coverage is gated at 80%** and currently sits near 99%. The gate is a floor
+  against regression, not a target. Never write a test purely to move the
+  number; if something genuinely cannot be covered, exclude it with
+  `# pragma: no cover` and say why.
+- **`pip-audit --strict` can turn CI red with no code change**, because a new
+  CVE was disclosed in a pinned dependency. Fix it by bumping the pin. This
+  service ships TLS calls and an API token, and `certifi` is its trust store.
+
+## Branching and pull requests
+
+`main` is protected and takes no direct pushes. Everything lands through a pull
+request that squash-merges into one commit.
+
+1. Branch from an up-to-date `main`, prefixing with `feat/`, `fix/`, `chore/`,
+   `docs/` or `refactor/`.
+2. Commit as you go. Messy branch commits are fine — the squash collapses them.
+3. Run the checks above.
+4. `git push -u origin HEAD && gh pr create`. Say what changed and why, and note
+   anything you deliberately did not do.
+5. Wait for review. Don't merge your own pull request unless asked to.
+
+Never force-push a branch that is under review.
+
+## Tests are owned by whoever wrote them
+
+The assertions in `tests/` are deliberately precise. `tests/test_pfsense.py`
+pins exact `requests` call sequences and keyword arguments, which is what makes
+a dropped `/apply` call or a weakened TLS `verify` fail loudly instead of
+silently.
+
+So changing a test is a decision, not a way to get to green. If a test seems to
+encode the wrong requirement, say so and get agreement before touching it.
+Difficulty satisfying a test is not evidence that the test is wrong. Reviewers
+check `git diff main...HEAD -- tests/` for exactly this.
+
+If you are working through the agent workflow described in `AGENTS.md`, this is
+a hard rule: the implementer may not edit `tests/` at all, and only the planner
+can approve a change to a test the tester already wrote.
+
+## Testing against a real pfSense
+
+The unit suite stubs both Docker and the pfSense API. That is what makes it fast
+and precise, but it also means it can only confirm the client matches *our own
+idea* of the API. It cannot tell you whether a change actually reaches unbound,
+whether a payload field lands where pfSense reads it, or whether a name really
+resolves afterwards.
+
+For that, `test-env/` builds a throwaway pfSense virtual machine with the REST
+API package installed:
+
+```bash
+test-env/bootstrap.sh    # about ten minutes, roughly 6 GB of disk
+test-env/smoke.sh        # run the service against it and assert end to end
+```
+
+`smoke.sh` starts the service, starts a labelled container, and asserts that the
+alias appears, resolves to the right address through the firewall's own
+resolver, disappears when the container stops, and that the service is still
+running at the end. `test-env/vm.sh reset` rolls back to a clean snapshot in
+about a second, so runs are repeatable.
+
+This needs KVM and cannot run on GitHub's runners, so it is not part of CI. It
+is worth doing by hand for any change that touches `pfsense.py`, the apply and
+coalescing logic, or anything about what actually goes into an API payload.
+
+`test-env/README.md` covers the scripts, the pinned versions, and the handful of
+things that will bite you. Two are worth knowing before you start:
+
+- Every request from the host reaches pfSense from a single address, so its
+  brute-force protection can lock out SSH, the webGUI and the REST API all at
+  once while the serial console still looks healthy. `bootstrap.sh` whitelists
+  that address, but it is the first thing to suspect if everything goes quiet.
+- Containers cannot reach the VM through QEMU's port forwarding directly; run
+  `test-env/relay.sh start` first. `smoke.sh` does this for you.
+
+There is also a much cheaper check that needs no pfSense at all — point the
+service at an unresolvable host and watch the retry and failure path, confirming
+it logs and keeps running rather than crashing. `AGENTS.md` has the commands
+under "Manual end-to-end check".
+
+## House style
+
+- Straightforward Python. Explicit names, boring control flow, no
+  over-engineering.
+- Keep configuration environment-variable driven, and keep Docker-based
+  deployment working.
+- Treat pfSense API credentials as sensitive. Never log tokens, authorization
+  headers or API response bodies.
+- Runtime dependencies are pinned in `requirements.txt`. Don't add one without
+  agreement first.
+- The `Dockerfile` copies only `main.py`, `pfsense.py` and `requirements.txt`. A
+  new runtime module needs a matching `COPY`, or the image builds cleanly and
+  dies at import.
+- Keep `README.md` and `docker-compose.yaml` aligned with the code when
+  environment variables or labels change.

--- a/README.md
+++ b/README.md
@@ -203,10 +203,11 @@ services:
 - Replace `caddy.lab.internal` with the fully qualified hostname of your reverse proxy. Make sure it exists as a host override in pfSense.
 - Replace `nginx.lab.internal` with the fully qualified hostname of the service you're deploying.
 - An alias longer than 253 characters is rejected with a warning and cannot be resolved by DNS anyway. If one already exists in pfSense from an earlier version of this service, remove it in the webGUI — this service will decline to touch it.
+- `pfsense.dns.remove_on_stop=true` does not combine reliably with `docker run --rm`. This service reads a stopping container's labels back from Docker, and Docker may already have deleted a container started with `--rm`, in which case the alias is left behind. A single container stopping on its own is usually fine; a batch stopping together is not. Prefer `docker compose` or a container without `--rm` when you rely on removal.
 
 ## Contributing 💻
 
-Contributions are welcome! Submit issues or pull requests on GitHub to help improve this project.
+Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) for how to get set up, what has to pass before a pull request, and how to test a change against a real pfSense using the throwaway VM in [`test-env/`](test-env/).
 
 ## License 📜
 

--- a/test-env/README.md
+++ b/test-env/README.md
@@ -1,0 +1,134 @@
+# Local end-to-end test environment
+
+A throwaway pfSense virtual machine with the REST API package installed, so
+changes can be tested against a real firewall instead of a mock.
+
+`CONTRIBUTING.md` explains when to reach for this. This file is the reference
+for the scripts themselves.
+
+## Build it
+
+```bash
+test-env/bootstrap.sh
+```
+
+About ten minutes and 6 GB of disk. It downloads pfSense, installs it over a
+serial console, installs the REST API package, creates an API key, creates the
+parent host override the service needs, and takes a snapshot.
+
+It needs KVM and a handful of packages. It checks for both and tells you the
+exact command to run if something is missing; `--install-deps` runs it for you
+on Debian and Ubuntu.
+
+Everything it creates lives outside the repository, under
+`~/.local/share/pfsense-docker-alias-lab` by default. Set `PFSENSE_LAB_DIR` to
+put it elsewhere. Nothing here writes into the working tree.
+
+## Use it
+
+```bash
+test-env/smoke.sh            # run the service against it and assert end to end
+test-env/smoke.sh --reset    # from the clean snapshot, for a repeatable run
+
+test-env/vm.sh start         # boot it
+test-env/vm.sh reset         # roll back to the clean snapshot, about a second
+test-env/vm.sh stop          # shut it down
+test-env/vm.sh status
+
+test-env/relay.sh start      # publish the API to Docker containers
+test-env/pf.sh 'pkg info'    # run a command on the firewall over SSH
+```
+
+Talking to the API by hand:
+
+```bash
+source ~/.local/share/pfsense-docker-alias-lab/lab.env
+curl -sk -H "X-API-Key: $PFSENSE_API_TOKEN" \
+  https://127.0.0.1:8443/api/v2/services/dns_resolver/host_overrides
+```
+
+Checking that an alias actually resolves, which is the assertion no unit test
+can make:
+
+```bash
+dig +short @127.0.0.1 -p 15353 smoke.lab.internal
+```
+
+## What you get
+
+| | |
+|---|---|
+| pfSense | CE 2.7.2-RELEASE, ZFS on a 20 GB qcow2 |
+| REST API | pfRest v2.4.3 |
+| WAN | `em0`, DHCP from QEMU user-mode networking, has internet |
+| LAN | `em1`, static `10.0.3.15/24` |
+| Parent host override | `caddy.lab.internal` → `10.0.3.100` |
+| webGUI | <https://127.0.0.1:8443/>, `admin` / `pfsense` |
+
+The two versions are pinned together in `lib/common.sh` and must move together.
+pfRest v2.4.3 is the last release built for pfSense CE 2.7.2; everything after
+it requires CE 2.8.x, whose installer images are not on Netgate's open mirror
+and can only be fetched through a form on pfsense.org. Bumping the package
+alone will not work.
+
+## Ports
+
+QEMU forwards to `127.0.0.1` only. This VM keeps pfSense's default credentials,
+so binding to `0.0.0.0` would publish its webGUI and SSH to the whole physical
+network.
+
+| Host | pfSense | |
+|---|---|---|
+| `127.0.0.1:8443` | 443 | webGUI and REST API |
+| `127.0.0.1:2222` | 22 | SSH |
+| `127.0.0.1:15353/udp` | 53 | unbound |
+| `172.17.0.1:8443` | — | `relay.sh`, for Docker containers |
+
+Containers cannot use QEMU's forwarding directly. A `hostfwd` rule bound to the
+Docker bridge address accepts the TCP connection and then carries no data, so
+the client sees a connect that succeeds followed by a read timeout. `relay.sh`
+socats the bridge address to the working loopback forward instead.
+
+## Things that bite
+
+**The lockout.** Every request from the host reaches pfSense as `10.0.3.2`, the
+QEMU user-mode gateway. pfSense's login protection blocks a source address after
+a few authentication failures, and it blocks *everything* from it at once —
+SSH, the webGUI and the REST API — while the serial console stays up and makes
+the VM look perfectly healthy. `bootstrap.sh` whitelists that address and turns
+off pfRest's own login protection. If you still manage to trip it:
+
+```bash
+PFSENSE_LAB_DIR=... python3 test-env/lib/sendkeys.py "pfctl -t sshguard -T flush{ENTER}"
+```
+
+**`--rm` and `remove_on_stop` do not reliably combine.** The service reads a
+stopping container's labels back from the Docker API, and Docker may have
+already deleted a container started with `--rm`. One container stopped on its
+own is usually fine; twenty stopped at once left 19 aliases orphaned. This is a
+property of the service, not of the test environment — `smoke.sh` avoids `--rm`
+deliberately.
+
+**Arrow keys cancel installer dialogs.** Over this serial console `dialog(1)`
+reads the leading ESC of `ESC [ B` as a bare escape and treats it as cancel,
+which quits the installer to a login prompt. Use TAB to move between buttons.
+`showcon.py` marks bold and reverse-video so you can see which button actually
+has focus, which is how `install.py` tells `<YES>` from `<NO>` on the
+confirmation that defaults to NO.
+
+## Files
+
+| | |
+|---|---|
+| `bootstrap.sh` | build the whole thing from nothing |
+| `smoke.sh` | run the service against it and assert end to end |
+| `vm.sh` | boot, stop, snapshot, roll back, QEMU monitor |
+| `relay.sh` | publish the API on the Docker bridge |
+| `pf.sh` | run a command on pfSense over SSH |
+| `lib/common.sh` | pinned versions, addresses, ports, shared helpers |
+| `lib/conmux.py` | owns the serial console; logs it and accepts keystrokes |
+| `lib/showcon.py` | render the console log as a screen, with focus markers |
+| `lib/sendkeys.py` | send keystrokes to the console |
+| `lib/expect.py` | drive a sequence of console prompts |
+| `lib/install.py` | drive the installer's dialog screens |
+| `lib/lab.py` | where the console helpers find the state directory |

--- a/test-env/bootstrap.sh
+++ b/test-env/bootstrap.sh
@@ -1,0 +1,292 @@
+#!/usr/bin/env bash
+# Build the pfSense test VM from nothing, unattended.
+#
+#   ./bootstrap.sh                 build it (refuses if a disk already exists)
+#   ./bootstrap.sh --force         delete any existing VM and build a new one
+#   ./bootstrap.sh --install-deps  apt-get the missing host packages first
+#
+# Takes roughly ten minutes and about 6 GB of disk. When it finishes there is a
+# running pfSense with the REST API package, an API key, an SSH key, the parent
+# host override this service expects, and a snapshot to roll back to.
+#
+# Everything it creates lives in $LAB_DIR, outside the repository.
+set -euo pipefail
+
+# shellcheck source=lib/common.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib/common.sh"
+
+FORCE=0
+INSTALL_DEPS=0
+for arg in "$@"; do
+  case "$arg" in
+    --force)        FORCE=1 ;;
+    --install-deps) INSTALL_DEPS=1 ;;
+    -h|--help)      sed -n '2,14p' "$0"; exit 0 ;;
+    *)              die "unknown option: $arg" ;;
+  esac
+done
+
+DISK="$LAB_DIR/pfsense.qcow2"
+KEY="$LAB_DIR/pfsense_lab_key"
+ENV_FILE="$LAB_DIR/lab.env"
+
+# pfSense's out-of-the-box webGUI login. Used only until the API key exists.
+DEFAULT_USER="admin"
+DEFAULT_PASS="pfsense"
+
+ssh_pw() {
+  sshpass -p "$DEFAULT_PASS" ssh \
+    -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+    -o LogLevel=ERROR -o PreferredAuthentications=password \
+    -o ConnectTimeout=10 -p "$SSH_PORT" "$DEFAULT_USER@127.0.0.1" "$@"
+}
+
+scp_key() {
+  scp -i "$KEY" -o IdentitiesOnly=yes \
+    -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+    -o LogLevel=ERROR -P "$SSH_PORT" "$1" "$DEFAULT_USER@127.0.0.1:$2"
+}
+
+pf() { "$TEST_ENV_DIR/pf.sh" "$@"; }
+vm() { "$TEST_ENV_DIR/vm.sh" "$@"; }
+console() { PFSENSE_LAB_DIR="$LAB_DIR" python3 "$TEST_ENV_DIR/lib/$1.py" "${@:2}"; }
+
+# wait_for DESCRIPTION TIMEOUT COMMAND...
+wait_for() {
+  local what="$1" timeout="$2"; shift 2
+  local waited=0
+  until "$@" >/dev/null 2>&1; do
+    sleep 3
+    waited=$(( waited + 3 ))
+    (( waited < timeout )) || die "timed out after ${timeout}s waiting for $what"
+  done
+}
+
+console_says() { grep -qa "$1" "$LAB_DIR/console.log"; }
+
+api_basic() {
+  local method="$1" path="$2"; shift 2
+  curl -sk --max-time 30 -X "$method" -u "$DEFAULT_USER:$DEFAULT_PASS" \
+    -H 'Content-Type: application/json' \
+    "https://127.0.0.1:${API_PORT}/api/v2${path}" "$@"
+}
+
+json_field() { python3 -c "import json,sys; print(json.load(sys.stdin)$1)"; }
+
+# --------------------------------------------------------------------------
+log "checking the host"
+
+MISSING=()
+for cmd in qemu-system-x86_64 qemu-img socat curl python3 dig ssh scp sshpass; do
+  command -v "$cmd" >/dev/null || MISSING+=("$cmd")
+done
+
+if (( ${#MISSING[@]} )); then
+  APT_PACKAGES="qemu-system-x86 qemu-utils socat curl python3 dnsutils openssh-client sshpass"
+  if (( INSTALL_DEPS )) && command -v apt-get >/dev/null; then
+    log "installing: $APT_PACKAGES"
+    # shellcheck disable=SC2086  # deliberate word splitting into package names
+    sudo apt-get install -y $APT_PACKAGES
+  else
+    die "missing: ${MISSING[*]}
+On Debian or Ubuntu: sudo apt-get install -y $APT_PACKAGES
+Or re-run with --install-deps. Other distributions need the equivalents."
+  fi
+fi
+
+if [[ ! -e /dev/kvm ]]; then
+  die "no /dev/kvm. This host cannot run KVM, so the test environment cannot be built here."
+elif [[ ! -r /dev/kvm || ! -w /dev/kvm ]]; then
+  if in_kvm_group; then
+    warn "you are in the kvm group but this shell predates it; QEMU will run under 'sg kvm'"
+  elif (( INSTALL_DEPS )); then
+    log "adding $USER to the kvm group"
+    sudo usermod -aG kvm "$USER"
+    in_kvm_group || die "usermod did not take effect"
+    warn "group membership applies to new logins; QEMU will run under 'sg kvm' for now"
+  else
+    die "no access to /dev/kvm. Run: sudo usermod -aG kvm $USER
+Then log out and back in, or start a new login session. Or re-run with
+--install-deps, which will do it for you."
+  fi
+fi
+
+# --------------------------------------------------------------------------
+if [[ -f "$DISK" ]]; then
+  (( FORCE )) || die "a VM already exists at $DISK. Re-run with --force to replace it."
+  log "removing the existing VM"
+  vm kill >/dev/null 2>&1 || true
+  "$TEST_ENV_DIR/relay.sh" stop >/dev/null 2>&1 || true
+  rm -f "$DISK" "$KEY" "$KEY.pub" "$ENV_FILE" \
+        "$LAB_DIR/console.log" "$LAB_DIR/console.fifo" "$LAB_DIR/qemu.pid"
+fi
+
+mkdir -p "$LAB_DIR"
+chmod 700 "$LAB_DIR"
+
+# --------------------------------------------------------------------------
+log "fetching pfSense CE $PFSENSE_VERSION"
+
+cd "$LAB_DIR"
+
+# A progress bar is worth having on a terminal and is unreadable in a log file.
+CURL=(curl -fL)
+if [[ -t 2 ]]; then CURL+=(--progress-bar); else CURL+=(-sS); fi
+
+if [[ ! -f "$PFSENSE_IMAGE" ]]; then
+  [[ -f "$PFSENSE_IMAGE.gz" ]] || "${CURL[@]}" -o "$PFSENSE_IMAGE.gz" "$PFSENSE_IMAGE_URL"
+  echo "$PFSENSE_IMAGE_SHA256  $PFSENSE_IMAGE.gz" | sha256sum -c - \
+    || die "checksum mismatch on $PFSENSE_IMAGE.gz — delete it and retry"
+  gunzip -kf "$PFSENSE_IMAGE.gz"
+fi
+
+[[ -f "$RESTAPI_PKG" ]] || "${CURL[@]}" -o "$RESTAPI_PKG" "$RESTAPI_URL"
+
+log "creating a 20 GB disk"
+qemu-img create -f qcow2 "$DISK" 20G >/dev/null
+
+# --------------------------------------------------------------------------
+log "installing pfSense (this is the slow part)"
+
+rm -f "$LAB_DIR/console.log"
+vm start install
+console install
+
+# The installer reboots into itself, because the memstick still boots first.
+# Give it a moment to finish writing, then bring it back up without the stick.
+sleep 20
+vm kill
+sleep 2
+rm -f "$LAB_DIR/console.log"
+vm start
+
+log "waiting for the first boot"
+wait_for "the console menu" 600 console_says "Enter an option"
+
+# --------------------------------------------------------------------------
+log "configuring the LAN interface"
+
+console sendkeys "{ENTER}"
+console expect \
+  "?Should VLANs be set up now=n" \
+  "Enter an option:=2" \
+  "the number of the interface you wish to configure=2" \
+  "via DHCP?=n" \
+  "new LAN IPv4 address=$LAN_IP" \
+  "subnet bit count=24" \
+  "press <ENTER> for none:=" \
+  "via DHCP6?=n" \
+  "new LAN IPv6 address=" \
+  "DHCP server on LAN=n" \
+  "revert to HTTP=n"
+
+wait_for "the webGUI" 300 curl -sk --max-time 5 -o /dev/null "https://127.0.0.1:${API_PORT}/"
+
+log "enabling SSH"
+console sendkeys "{ENTER}"
+console expect "Enter an option:=14" "Would you like to enable?=y"
+wait_for "sshd" 180 ssh_pw true
+
+# --------------------------------------------------------------------------
+log "installing the REST API package ($RESTAPI_VERSION)"
+
+ssh-keygen -t ed25519 -N '' -f "$KEY" -C 'pfsense-docker-alias test env' >/dev/null
+ssh_pw "mkdir -p /root/.ssh && chmod 700 /root/.ssh && \
+        cat >> /root/.ssh/authorized_keys && chmod 600 /root/.ssh/authorized_keys" < "$KEY.pub"
+
+scp_key "$LAB_DIR/$RESTAPI_PKG" /tmp/
+pf "pkg-static add /tmp/$RESTAPI_PKG" | tail -3
+
+wait_for "the API after the webConfigurator restart" 300 \
+  curl -sk --max-time 5 -o /dev/null "https://127.0.0.1:${API_PORT}/api/v2/status/system"
+
+# --------------------------------------------------------------------------
+log "configuring the API"
+
+# pfRest ships with only BasicAuth enabled, so the X-API-Key header this project
+# sends is rejected with a 401 until KeyAuth is added. login_protection is turned
+# off for the reason described under "the lockout" in the README.
+api_basic PATCH /system/restapi/settings \
+  -d '{"auth_methods":["BasicAuth","KeyAuth"],"login_protection":false}' \
+  | json_field "['data']['auth_methods']" >/dev/null
+
+PFSENSE_API_TOKEN="$(
+  api_basic POST /auth/key -d '{"descr":"pfsense-docker-alias test env"}' \
+    | json_field "['data']['key']"
+)"
+export PFSENSE_API_TOKEN
+[[ -n "$PFSENSE_API_TOKEN" ]] || die "the API did not return a key"
+
+# A key written straight into /root/.ssh/authorized_keys is wiped on reboot;
+# pfSense rewrites that file from its user configuration. Store it on the admin
+# user so it survives.
+ADMIN_ID="$(api GET /users | json_field "['data'][0]['id']")"
+python3 -c "
+import json, sys
+print(json.dumps({'id': int(sys.argv[1]), 'authorizedkeys': open(sys.argv[2]).read().strip()}))
+" "$ADMIN_ID" "$KEY.pub" > "$LAB_DIR/user.json"
+api PATCH /user -d @"$LAB_DIR/user.json" | json_field "['code']" >/dev/null
+rm -f "$LAB_DIR/user.json"
+
+# --------------------------------------------------------------------------
+log "whitelisting the gateway from login protection"
+
+# Every request from the host reaches pfSense from the QEMU user-mode gateway
+# address, so a handful of authentication failures would otherwise lock out SSH,
+# the webGUI and the REST API all at once.
+cat > "$LAB_DIR/whitelist.php" <<PHP
+<?php
+require_once("config.inc");
+require_once("syslog.inc");
+config_set_path('system/sshguard_whitelist', '$LAN_GATEWAY');
+write_config("test env: whitelist the QEMU gateway from login protection");
+system_syslogd_start();
+PHP
+scp_key "$LAB_DIR/whitelist.php" /tmp/whitelist.php
+pf 'php -f /tmp/whitelist.php && pfctl -t sshguard -T flush' >/dev/null 2>&1
+rm -f "$LAB_DIR/whitelist.php"
+
+# --------------------------------------------------------------------------
+log "creating the parent host override"
+
+# This service never creates a host override, only aliases on one that already
+# exists, so a test environment needs one to hang aliases from.
+api POST /services/dns_resolver/host_override \
+  -d "{\"host\":\"$PARENT_HOST\",\"domain\":\"$PARENT_DOMAIN\",\"ip\":[\"$PARENT_IP\"],\"descr\":\"test env parent override\"}" \
+  | json_field "['code']" >/dev/null
+api POST /services/dns_resolver/apply >/dev/null
+
+wait_for "the parent override to resolve" 120 \
+  dig +short +timeout=3 "@127.0.0.1" -p "$DNS_PORT" "$PARENT_HOST.$PARENT_DOMAIN"
+
+# --------------------------------------------------------------------------
+log "writing credentials and taking a snapshot"
+
+cat > "$ENV_FILE" <<ENV
+# Credentials for the local pfSense test VM, generated by test-env/bootstrap.sh.
+# Test-only: this VM sits behind QEMU user-mode NAT with its ports bound to
+# loopback, and it still uses pfSense's default webGUI password.
+PFSENSE_HOSTNAME=${BRIDGE_IP}:${API_PORT}
+PFSENSE_API_TOKEN=${PFSENSE_API_TOKEN}
+PFSENSE_VERIFY_SSL=false
+ENV
+chmod 600 "$ENV_FILE"
+
+vm snapshot clean >/dev/null
+
+cat <<SUMMARY
+
+$(log "ready")
+
+  VM state      $LAB_DIR
+  credentials   $ENV_FILE
+  webGUI        https://127.0.0.1:${API_PORT}/  ($DEFAULT_USER / $DEFAULT_PASS)
+  parent name   $PARENT_HOST.$PARENT_DOMAIN -> $PARENT_IP
+
+Next:
+
+  test-env/smoke.sh          run the service against it and assert end to end
+  test-env/vm.sh reset       roll back to the clean snapshot
+  test-env/vm.sh stop        shut it down
+
+SUMMARY

--- a/test-env/lib/common.sh
+++ b/test-env/lib/common.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Shared settings for the pfSense test environment. Sourced, not run.
+#
+# The VM's disk and credentials are deliberately kept outside the repository:
+# the qcow2 alone is several gigabytes, and lab.env holds an API key.
+
+# Repository directory holding these scripts.
+TEST_ENV_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+export TEST_ENV_DIR
+
+# Where the VM's disk, snapshots, keys and credentials live. Override by
+# exporting PFSENSE_LAB_DIR before calling any of these scripts.
+LAB_DIR="${PFSENSE_LAB_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/pfsense-docker-alias-lab}"
+export LAB_DIR
+
+# pfSense CE 2.7.2 is the newest release whose installer images Netgate serves
+# from an open mirror; 2.8.x is only available through a form on pfsense.org.
+# The REST API package is pinned to match: pfRest v2.4.3 is the last release
+# built for 2.7.2, and every release after it requires 2.8.x. Bump these two
+# together or not at all.
+PFSENSE_VERSION="2.7.2"
+PFSENSE_IMAGE="pfSense-CE-memstick-serial-${PFSENSE_VERSION}-RELEASE-amd64.img"
+PFSENSE_IMAGE_URL="https://atxfiles.netgate.com/mirror/downloads/${PFSENSE_IMAGE}.gz"
+PFSENSE_IMAGE_SHA256="bc3ee3d82b8195387114a64c3398505f238a6cb5393ae9b2d45d1bf9408ed192"
+
+RESTAPI_VERSION="v2.4.3"
+RESTAPI_PKG="pfSense-${PFSENSE_VERSION}-pkg-RESTAPI.pkg"
+RESTAPI_URL="https://github.com/pfrest/pfSense-pkg-RESTAPI/releases/download/${RESTAPI_VERSION}/${RESTAPI_PKG}"
+
+# Guest addressing. The LAN address is fixed because QEMU's port forwarding
+# rules name it explicitly.
+LAN_IP="10.0.3.15"
+LAN_GATEWAY="10.0.3.2"        # the QEMU user-mode gateway: every request from
+                              # the host reaches pfSense from this address
+PARENT_HOST="caddy"
+PARENT_DOMAIN="lab.internal"
+PARENT_IP="10.0.3.100"
+
+# Host-side ports. All bind to loopback only; see run notes in vm.sh.
+API_PORT="8443"
+SSH_PORT="2222"
+DNS_PORT="15353"
+
+# Where containers reach the API, via relay.sh.
+BRIDGE_IP="172.17.0.1"
+
+export PFSENSE_VERSION PFSENSE_IMAGE PFSENSE_IMAGE_URL PFSENSE_IMAGE_SHA256
+export RESTAPI_VERSION RESTAPI_PKG RESTAPI_URL
+export LAN_IP LAN_GATEWAY PARENT_HOST PARENT_DOMAIN PARENT_IP
+export API_PORT SSH_PORT DNS_PORT BRIDGE_IP
+
+log()  { printf '\033[1m==>\033[0m %s\n' "$*"; }
+warn() { printf '\033[33mwarning:\033[0m %s\n' "$*" >&2; }
+die()  { printf '\033[31merror:\033[0m %s\n' "$*" >&2; exit 1; }
+
+# QEMU needs read/write on /dev/kvm, which normally means membership of the kvm
+# group. A fresh group membership does not apply to already-running shells, so
+# run QEMU under `sg` when the current process cannot open the device yet.
+#
+# Note the argument to `id`: bare `id -nG` reports the calling process's own
+# credentials, which is exactly what has not caught up yet after a usermod.
+# Naming the user makes it consult the group database instead, which is the
+# question actually being asked.
+in_kvm_group() { id -nG "$USER" | tr ' ' '\n' | grep -qx kvm; }
+
+kvm_run() {
+  if [[ -r /dev/kvm && -w /dev/kvm ]]; then
+    "$@"
+  elif in_kvm_group; then
+    sg kvm -c "$(printf '%q ' "$@")"
+  else
+    die "no access to /dev/kvm. Run: sudo usermod -aG kvm $USER"
+  fi
+}
+
+api() {
+  # api METHOD PATH [curl args...]
+  local method="$1" path="$2"; shift 2
+  curl -sk --max-time 30 -X "$method" \
+    -H "X-API-Key: ${PFSENSE_API_TOKEN:?PFSENSE_API_TOKEN is not set}" \
+    -H 'Content-Type: application/json' \
+    "https://127.0.0.1:${API_PORT}/api/v2${path}" "$@"
+}

--- a/test-env/lib/conmux.py
+++ b/test-env/lib/conmux.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Multiplex the VM's serial console.
+
+QEMU's chardev socket accepts one client at a time, so a single process owns
+it. Everything the console prints is appended to a log file, and anything
+written to a FIFO is sent to the console as keystrokes. That lets the other
+helpers both watch and drive the console without fighting over the socket.
+
+    ./conmux.py console.sock console.log console.fifo
+"""
+import os
+import selectors
+import socket
+import sys
+
+sock_path, log_path, fifo_path = sys.argv[1:4]
+
+if not os.path.exists(fifo_path):
+    os.mkfifo(fifo_path)
+
+console = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+console.connect(sock_path)
+console.setblocking(False)
+
+log = open(log_path, 'ab', buffering=0)
+
+# Opening the FIFO read-write keeps it open across writer disconnects, so the
+# selector does not spin on EOF every time a writer finishes.
+fifo = os.open(fifo_path, os.O_RDWR | os.O_NONBLOCK)
+
+sel = selectors.DefaultSelector()
+sel.register(console, selectors.EVENT_READ, 'console')
+sel.register(fifo, selectors.EVENT_READ, 'fifo')
+
+# pfSense runs resizewin from its shell profile, which asks the terminal how
+# big it is and blocks until it answers. Nothing here is a real terminal, so
+# without these replies every shell prompt stalls and fills the log with
+# "resizewin: timeout reading from terminal".
+ANSWERS = {
+    b'\x1b[6n': b'\x1b[24;80R',      # cursor position report
+    b'\x1b[18t': b'\x1b[8;24;80t',   # window size in characters
+}
+
+while True:
+    for key, _ in sel.select():
+        if key.data == 'console':
+            data = console.recv(65536)
+            if not data:
+                sys.exit(0)
+            log.write(data)
+            for query, answer in ANSWERS.items():
+                if query in data:
+                    console.sendall(answer)
+        else:
+            data = os.read(fifo, 65536)
+            if data:
+                console.sendall(data)

--- a/test-env/lib/expect.py
+++ b/test-env/lib/expect.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Drive a line-oriented console prompt sequence.
+
+pfSense's console menu asks a series of plain text questions rather than
+drawing dialogs, so this waits for each prompt to appear in the console log and
+then sends the answer. Matching is against text that has arrived since the
+previous step, so a phrase appearing in two prompts cannot make a later step
+fire early.
+
+    ./expect.py "Enter an option:=2" "interface you wish=2" ...
+
+Each argument is `substring=response`. The response is sent followed by a
+carriage return; an empty response sends a bare carriage return. Exits non-zero
+on the first prompt that does not arrive, printing what the console showed
+instead.
+
+Prefixing a step with `?` makes it optional: it waits briefly, answers if the
+prompt shows up, and otherwise moves on without consuming any output. That is
+for questions pfSense asks only sometimes, such as the VLAN prompt on a first
+boot where it could not assign the interfaces on its own.
+"""
+import sys
+import time
+
+import lab
+
+TIMEOUT = 120
+OPTIONAL_TIMEOUT = 25
+
+# Start a little way back from the end of the log rather than exactly at it:
+# the first prompt of a sequence has usually already been printed by the time
+# this runs, and seeking to the end would wait forever for output that has
+# already arrived.
+LOOKBACK = 2000
+
+
+def read_from(offset):
+    with open(lab.CONSOLE_LOG, 'rb') as log:
+        log.seek(offset)
+        return log.read().decode('utf-8', 'replace')
+
+
+with open(lab.CONSOLE_LOG, 'rb') as handle:
+    handle.seek(0, 2)
+    offset = max(0, handle.tell() - LOOKBACK)
+
+for arg in sys.argv[1:]:
+    optional = arg.startswith('?')
+    marker, _, response = arg.lstrip('?').partition('=')
+    deadline = time.time() + (OPTIONAL_TIMEOUT if optional else TIMEOUT)
+    matched = True
+    while marker not in (fresh := read_from(offset)):
+        if time.time() > deadline:
+            if optional:
+                matched = False
+                break
+            print(f'TIMEOUT waiting for {marker!r}. Console showed:\n{fresh[-800:]}')
+            sys.exit(1)
+        time.sleep(1)
+
+    if not matched:
+        print(f'  {marker!r} did not appear; skipping (optional)', flush=True)
+        continue
+
+    # Consume up to and including the matched prompt so the next step only
+    # matches on genuinely new output. An optional step that never matched
+    # leaves the offset alone, so a later step can still see this window.
+    consumed = fresh[:fresh.index(marker) + len(marker)]
+    offset += len(consumed.encode('utf-8', 'replace'))
+
+    print(f'  {marker!r} -> {response!r}', flush=True)
+    time.sleep(1)
+    lab.send(response + '\r')

--- a/test-env/lib/install.py
+++ b/test-env/lib/install.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Drive the pfSense installer's dialog screens over the serial console.
+
+Sending keystrokes on a timer does not work: a screen that takes longer than
+expected swallows the keys meant for the next one. So this waits for the screen
+to settle, matches it against the rule table, sends that rule's keys, and waits
+for the screen to change before matching again. If nothing matches for long
+enough it prints the screen and fails, rather than guessing.
+
+Two details are load-bearing:
+
+* Arrow keys must not be used. Over this serial console dialog(1) reads the
+  leading ESC of "ESC [ B" as a bare escape and cancels the dialog, which quits
+  the installer to a login prompt. TAB moves between buttons instead.
+* The "Last Chance" confirmation defaults to NO, and nothing on a monochrome
+  screen distinguishes the focused button except that dialog draws its brackets
+  in bold. showcon.py marks bold with single angle quotes, which is what lets
+  the rules below tell "focus is on NO, press TAB" from "focus is on YES, press
+  ENTER" instead of pressing blind.
+
+Those markers are also why matching happens against the marked screen and a
+marker-stripped copy of it together. dialog highlights the hotkey letter inside
+a word, so the marked screen renders "vtbd0" as "‹v›tbd0" and a plain substring
+search for the device name silently never matches.
+"""
+import hashlib
+import os
+import subprocess
+import sys
+import time
+
+import lab
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+ENTER = '\r'
+SPACE = ' '
+TAB = '\t'
+
+# (description, [every one of these must be on screen], keys, is_last_step)
+RULES = [
+    ('console type',        ['Console type'],                             ENTER, False),
+    ('copyright notice',    ['Copyright', 'Accept'],                      ENTER, False),
+    ('welcome menu',        ['Welcome to pfSense!', 'Install pfSense'],   ENTER, False),
+    ('partitioning',        ['How would you like to partition'],          ENTER, False),
+    ('zfs menu',            ['ZFS Configuration', 'Proceed with'],        ENTER, False),
+    ('vdev type',           ['Virtual Device type'],                      ENTER, False),
+    ('select the disk',     ['vtbd0', '[ ]'],                             SPACE, False),
+    ('confirm the disk',    ['vtbd0', '[*]'],                             ENTER, False),
+    ('last chance, on NO',  ['Last Chance', '‹<› NO'],          TAB,   False),
+    ('last chance, on YES', ['Last Chance', '‹<› YES'],         ENTER, False),
+    ('reboot when done',    ['Installation of pfSense complete'],         ENTER, True),
+]
+
+OVERALL_TIMEOUT = 1800
+NO_MATCH_TIMEOUT = 600   # the install itself shows a progress screen for a while
+
+
+MARKERS = str.maketrans('', '', '«»‹›')
+
+
+def screen():
+    """The rendered screen, followed by the same screen without focus markers.
+
+    Rules are matched against the pair, so a rule can ask about focus using the
+    markers while a rule about ordinary text is not defeated by a marker landing
+    in the middle of a word.
+    """
+    out = subprocess.run(
+        [sys.executable, os.path.join(HERE, 'showcon.py'), lab.CONSOLE_LOG],
+        capture_output=True, text=True, check=True,
+    )
+    marked = out.stdout
+    return marked + '\n' + marked.translate(MARKERS)
+
+
+def digest(text):
+    return hashlib.sha256(text.encode()).hexdigest()
+
+
+def settle(quiet=3.0, timeout=300):
+    """Wait until the screen stops changing for `quiet` seconds."""
+    deadline = time.time() + timeout
+    last, last_change = None, time.time()
+    while time.time() < deadline:
+        current = digest(screen())
+        if current != last:
+            last, last_change = current, time.time()
+        elif time.time() - last_change >= quiet:
+            return
+        time.sleep(1)
+
+
+started = time.time()
+unmatched_since = None
+
+while True:
+    if time.time() - started > OVERALL_TIMEOUT:
+        print('installer did not finish within the overall timeout')
+        print(screen())
+        sys.exit(1)
+
+    settle()
+    view = screen()
+
+    for name, markers, keys, is_last in RULES:
+        if all(marker in view for marker in markers):
+            print(f'  {name}', flush=True)
+            unmatched_since = None
+            before = digest(view)
+            lab.send(keys)
+            if is_last:
+                print('installer finished', flush=True)
+                sys.exit(0)
+            for _ in range(120):
+                time.sleep(1)
+                if digest(screen()) != before:
+                    break
+            break
+    else:
+        now = time.time()
+        unmatched_since = unmatched_since or now
+        if now - unmatched_since > NO_MATCH_TIMEOUT:
+            print('no installer screen matched for too long. Console showed:\n')
+            print(view)
+            sys.exit(1)
+        time.sleep(5)

--- a/test-env/lib/lab.py
+++ b/test-env/lib/lab.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+"""Paths shared by the console helpers.
+
+The VM's state lives outside the repository: the disk image is several
+gigabytes and lab.env holds an API key. Set PFSENSE_LAB_DIR to move it.
+"""
+import os
+
+LAB_DIR = os.environ.get('PFSENSE_LAB_DIR') or os.path.join(
+    os.environ.get('XDG_DATA_HOME') or os.path.expanduser('~/.local/share'),
+    'pfsense-docker-alias-lab',
+)
+
+CONSOLE_LOG = os.path.join(LAB_DIR, 'console.log')
+CONSOLE_FIFO = os.path.join(LAB_DIR, 'console.fifo')
+CONSOLE_SOCK = os.path.join(LAB_DIR, 'console.sock')
+
+
+def send(text):
+    """Write keystrokes to the console FIFO that conmux.py is reading."""
+    with open(CONSOLE_FIFO, 'wb') as fifo:
+        fifo.write(text.encode())

--- a/test-env/lib/sendkeys.py
+++ b/test-env/lib/sendkeys.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Send keystrokes to the VM's serial console.
+
+Literal text is sent as-is; the braced names below become the control or escape
+sequences a terminal would send.
+
+    ./sendkeys.py "{ENTER}"
+    ./sendkeys.py "pfctl -t sshguard -T flush{ENTER}"
+
+Note that arrow keys are unreliable in the installer's dialogs: over this serial
+console dialog(1) reads the leading ESC of "ESC [ B" as a bare escape and treats
+it as cancel. Use {TAB} to move between buttons.
+"""
+import re
+import sys
+
+import lab
+
+KEYS = {
+    'ENTER': '\r',
+    'TAB': '\t',
+    'SPACE': ' ',
+    'ESC': '\x1b',
+    'BS': '\x7f',
+    'UP': '\x1b[A',
+    'DOWN': '\x1b[B',
+    'RIGHT': '\x1b[C',
+    'LEFT': '\x1b[D',
+    'CTRL-C': '\x03',
+}
+
+out = []
+for part in re.split(r'(\{[A-Z-]+\})', ' '.join(sys.argv[1:])):
+    name = part[1:-1] if part.startswith('{') and part.endswith('}') else None
+    out.append(KEYS[name] if name in KEYS else part)
+
+lab.send(''.join(out))

--- a/test-env/lib/showcon.py
+++ b/test-env/lib/showcon.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Render the tail of the serial console log as a readable screen.
+
+The installer draws with ncurses, so the raw log is mostly escape sequences.
+This replays the cursor movements onto a 24x80 grid and prints the result,
+which is what a human would actually be looking at.
+
+Reverse-video text is wrapped in guillemets and bold text in single angle
+quotes, because that is how dialog(1) shows which button or menu entry has
+focus. Without it there is no way to tell a highlighted <YES> from an
+unhighlighted one, and pressing an arrow key to "move to" a button that
+already has focus can move away from it instead.
+
+    ./showcon.py console.log [rows] [cols]
+"""
+import re
+import sys
+
+path = sys.argv[1]
+rows = int(sys.argv[2]) if len(sys.argv) > 2 else 24
+cols = int(sys.argv[3]) if len(sys.argv) > 3 else 80
+
+data = open(path, 'rb').read().decode('utf-8', 'replace')
+
+grid = [[' '] * cols for _ in range(rows)]
+attr = [[0] * cols for _ in range(rows)]
+row = col = 0
+reverse = False
+bold = False
+
+# Only the sequences the installer actually uses need handling; anything else
+# is dropped so it cannot corrupt the rendering.
+token = re.compile(r'\x1b\[([0-9;?]*)([A-Za-z])|\x1b([()][A-Za-z0-9])|\x1b(.)|(.)', re.S)
+
+
+def clamp():
+    global row, col
+    row = max(0, min(rows - 1, row))
+    col = max(0, min(cols - 1, col))
+
+
+def scroll():
+    global row
+    if row >= rows:
+        grid.append([' '] * cols)
+        attr.append([0] * cols)
+        del grid[0]
+        del attr[0]
+        row = rows - 1
+
+
+def blank_row(r):
+    grid[r] = [' '] * cols
+    attr[r] = [0] * cols
+
+
+for m in token.finditer(data):
+    params, final, charset, esc, ch = m.groups()
+    if final:
+        nums = [int(n) for n in params.split(';') if n.isdigit()] if params else []
+        first = nums[0] if nums else 1
+        if final in 'Hf':
+            row = (nums[0] - 1) if len(nums) > 0 else 0
+            col = (nums[1] - 1) if len(nums) > 1 else 0
+        elif final == 'A':
+            row -= first
+        elif final == 'B':
+            row += first
+        elif final == 'C':
+            col += first
+        elif final == 'D':
+            col -= first
+        elif final == 'm':
+            for n in (nums or [0]):
+                if n == 0:
+                    reverse = bold = False
+                elif n == 1:
+                    bold = True
+                elif n == 7:
+                    reverse = True
+                elif n == 22:
+                    bold = False
+                elif n == 27:
+                    reverse = False
+        elif final == 'J':
+            mode = nums[0] if nums else 0
+            if mode == 2:
+                for r in range(rows):
+                    blank_row(r)
+                row = col = 0
+            elif mode == 0:
+                grid[row][col:] = [' '] * (cols - col)
+                attr[row][col:] = [0] * (cols - col)
+                for r in range(row + 1, rows):
+                    blank_row(r)
+        elif final == 'K':
+            mode = nums[0] if nums else 0
+            if mode == 0:
+                grid[row][col:] = [' '] * (cols - col)
+                attr[row][col:] = [0] * (cols - col)
+            elif mode == 2:
+                blank_row(row)
+        clamp()
+    elif charset or esc:
+        continue
+    elif ch:
+        if ch == '\n':
+            row += 1
+            scroll()
+        elif ch == '\r':
+            col = 0
+        elif ch == '\b':
+            col = max(0, col - 1)
+        elif ch == '\t':
+            col = min(cols - 1, (col // 8 + 1) * 8)
+        elif ch == '\x07':
+            continue
+        elif ch >= ' ':
+            if col >= cols:
+                col = 0
+                row += 1
+                scroll()
+            clamp()
+            grid[row][col] = ch
+            attr[row][col] = (1 if reverse else 0) | (2 if bold else 0)
+            col += 1
+
+OPEN = {1: '«', 2: '‹', 3: '«‹'}
+CLOSE = {1: '»', 2: '›', 3: '›»'}
+
+for r in range(rows):
+    out = []
+    state = 0
+    for c in range(cols):
+        cell = attr[r][c]
+        if cell != state:
+            if state:
+                out.append(CLOSE[state])
+            if cell:
+                out.append(OPEN[cell])
+            state = cell
+        out.append(grid[r][c])
+    if state:
+        out.append(CLOSE[state])
+    print(''.join(out).rstrip())

--- a/test-env/pf.sh
+++ b/test-env/pf.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Run a command on the pfSense test VM over SSH, as root.
+#
+#   ./pf.sh 'pkg info | grep RESTAPI'
+#   ./pf.sh 'cat /etc/version'
+set -euo pipefail
+
+# shellcheck source=lib/common.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib/common.sh"
+
+KEY="$LAB_DIR/pfsense_lab_key"
+[[ -f "$KEY" ]] || die "no SSH key at $KEY — run ./bootstrap.sh first"
+
+# IdentitiesOnly stops ssh offering every key in the agent first. pfSense's sshd
+# rejects the connection as "Too many authentication failures" before it ever
+# reaches the right key, and each rejected offer counts toward the brute-force
+# lockout described in the README.
+exec ssh -i "$KEY" \
+  -o IdentitiesOnly=yes \
+  -o StrictHostKeyChecking=no \
+  -o UserKnownHostsFile=/dev/null \
+  -o LogLevel=ERROR \
+  -o ConnectTimeout=10 \
+  -p "$SSH_PORT" admin@127.0.0.1 "$@"

--- a/test-env/relay.sh
+++ b/test-env/relay.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Publish the pfSense REST API to Docker containers.
+#
+# QEMU's own port forwarding only works on loopback here: a hostfwd rule bound
+# to the Docker bridge address accepts the connection and then carries no data,
+# which a client sees as a connect that succeeds followed by a read timeout. So
+# the VM forwards to 127.0.0.1 and this relays the bridge address to it.
+#
+# The bind is the bridge address specifically, not 0.0.0.0, so the physical
+# network still cannot reach a VM running with pfSense's default credentials.
+#
+#   ./relay.sh start
+#   ./relay.sh stop
+#   ./relay.sh status
+set -euo pipefail
+
+# shellcheck source=lib/common.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib/common.sh"
+
+PIDFILE="$LAB_DIR/relay.pid"
+
+relay_running() {
+  [[ -f "$PIDFILE" ]] && kill -0 "$(cat "$PIDFILE")" 2>/dev/null
+}
+
+case "${1:-start}" in
+  start)
+    if relay_running; then
+      log "relay already running (pid $(cat "$PIDFILE"))"
+      exit 0
+    fi
+    ip -br addr show docker0 >/dev/null 2>&1 || \
+      warn "docker0 not present; the relay will fail to bind $BRIDGE_IP"
+    setsid socat "TCP-LISTEN:${API_PORT},bind=${BRIDGE_IP},fork,reuseaddr" \
+      "TCP:127.0.0.1:${API_PORT}" >"$LAB_DIR/relay.log" 2>&1 &
+    echo $! >"$PIDFILE"
+    sleep 1
+    relay_running || { cat "$LAB_DIR/relay.log" >&2; die "relay failed to start"; }
+    log "relay started: ${BRIDGE_IP}:${API_PORT} -> 127.0.0.1:${API_PORT}"
+    ;;
+  stop)
+    if relay_running; then
+      kill "$(cat "$PIDFILE")" 2>/dev/null || true
+      rm -f "$PIDFILE"
+      log "relay stopped"
+    else
+      rm -f "$PIDFILE"
+      log "relay not running"
+    fi
+    ;;
+  status)
+    if relay_running; then log "relay running (pid $(cat "$PIDFILE"))"; else log "relay not running"; fi
+    ;;
+  *)
+    die "usage: $0 {start|stop|status}"
+    ;;
+esac

--- a/test-env/smoke.sh
+++ b/test-env/smoke.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# Run the service against the test VM and assert the whole path end to end.
+#
+#   ./smoke.sh            run against the VM as it stands
+#   ./smoke.sh --reset    roll back to the clean snapshot first
+#
+# This is the check the unit suite structurally cannot make. That suite stubs
+# both Docker and the pfSense API, so it can only confirm the client matches our
+# own idea of the API. Here a container start has to travel through the real
+# Docker event stream, the real REST API and a real unbound reload before a DNS
+# query answers.
+#
+# Runs every assertion, then exits non-zero if any of them failed.
+set -euo pipefail
+
+# shellcheck source=lib/common.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib/common.sh"
+
+REPO_DIR="$(cd "$TEST_ENV_DIR/.." && pwd)"
+SERVICE="smoke-alias-service"
+TARGET="smoke-target"
+ALIAS_NAME="smoke.$PARENT_DOMAIN"
+DESCRIPTION="set by smoke.sh"
+IMAGE="pfsense-docker-alias:smoke"
+
+FAILURES=0
+
+pass() { printf '  \033[32mok\033[0m   %s\n' "$*"; }
+fail() { printf '  \033[31mFAIL\033[0m %s\n' "$*"; FAILURES=$(( FAILURES + 1 )); }
+
+cleanup() {
+  docker rm -f "$SERVICE" "$TARGET" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+resolves()     { [[ -n "$(dig +short +timeout=3 "@127.0.0.1" -p "$DNS_PORT" "$1" 2>/dev/null)" ]]; }
+not_resolves() { ! resolves "$1"; }
+logged()       { docker logs "$SERVICE" 2>&1 | grep -q "$1"; }
+
+# assert_within DESCRIPTION TIMEOUT PREDICATE [ARGS...]
+#
+# The predicate must be a function or command, not a pipeline: everything after
+# the timeout is passed to it as arguments. Always returns 0 so that one failed
+# assertion does not abort the run under `set -e`; failures are counted instead
+# and reported at the end.
+assert_within() {
+  local what="$1" timeout="$2"; shift 2
+  local waited=0
+  until "$@" >/dev/null 2>&1; do
+    sleep 3
+    waited=$(( waited + 3 ))
+    if (( waited >= timeout )); then
+      fail "$what (gave up after ${timeout}s)"
+      return 0
+    fi
+  done
+  pass "$what"
+}
+
+# --------------------------------------------------------------------------
+[[ -f "$LAB_DIR/lab.env" ]] || die "no test environment yet — run ./bootstrap.sh"
+"$TEST_ENV_DIR/vm.sh" status | grep -q running || die "the VM is not running — run ./vm.sh start"
+
+if [[ "${1:-}" == "--reset" ]]; then
+  log "rolling back to the clean snapshot"
+  "$TEST_ENV_DIR/vm.sh" reset clean >/dev/null
+  sleep 5
+fi
+
+"$TEST_ENV_DIR/relay.sh" start >/dev/null
+
+PFSENSE_API_TOKEN="$(grep '^PFSENSE_API_TOKEN=' "$LAB_DIR/lab.env" | cut -d= -f2-)"
+export PFSENSE_API_TOKEN
+
+log "building the image"
+docker build -q -t "$IMAGE" "$REPO_DIR" >/dev/null
+
+log "starting the service"
+cleanup
+docker run -d --name "$SERVICE" \
+  --env-file "$LAB_DIR/lab.env" \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  "$IMAGE" >/dev/null
+
+assert_within "the service reaches its event loop" 60 logged "Listening for container start"
+
+# --------------------------------------------------------------------------
+log "a labelled container should create an alias that resolves"
+
+# Deliberately not --rm. A container Docker has already deleted cannot have its
+# labels read back when it stops, so its alias is left behind; see the README.
+docker run -d --name "$TARGET" \
+  -l "pfsense.dns.override=$PARENT_HOST.$PARENT_DOMAIN" \
+  -l "pfsense.dns.alias=$ALIAS_NAME" \
+  -l "pfsense.dns.description=$DESCRIPTION" \
+  -l "pfsense.dns.remove_on_stop=true" \
+  alpine sleep 600 >/dev/null
+
+assert_within "the service logs the alias as added" 120 logged "$ALIAS_NAME added"
+assert_within "$ALIAS_NAME resolves" 120 resolves "$ALIAS_NAME"
+
+ANSWER="$(dig +short +timeout=3 "@127.0.0.1" -p "$DNS_PORT" "$ALIAS_NAME")"
+if [[ "$ANSWER" == "$PARENT_IP" ]]; then
+  pass "it resolves to the parent's address ($PARENT_IP)"
+else
+  fail "expected $PARENT_IP, got '${ANSWER:-nothing}'"
+fi
+
+STORED="$(api GET /services/dns_resolver/host_overrides | python3 -c "
+import json, sys
+for override in json.load(sys.stdin)['data']:
+    for alias in override.get('aliases') or []:
+        if alias.get('host') == '${ALIAS_NAME%%.*}':
+            print(alias.get('descr', ''))
+")"
+if [[ "$STORED" == "$DESCRIPTION" ]]; then
+  pass "the description round-trips through the API"
+else
+  fail "description was '$STORED', expected '$DESCRIPTION'"
+fi
+
+# --------------------------------------------------------------------------
+log "stopping it should remove the alias"
+
+docker stop "$TARGET" >/dev/null
+
+assert_within "the service logs the alias as removed" 120 logged "$ALIAS_NAME removed"
+assert_within "$ALIAS_NAME stops resolving" 120 not_resolves "$ALIAS_NAME"
+
+# --------------------------------------------------------------------------
+log "the service should still be running"
+
+if [[ "$(docker inspect -f '{{.State.Running}}' "$SERVICE" 2>/dev/null)" == "true" ]]; then
+  pass "it survived the whole run"
+else
+  fail "the service exited"
+  docker logs "$SERVICE" 2>&1 | tail -20
+fi
+
+echo
+if (( FAILURES )); then
+  die "$FAILURES assertion(s) failed"
+fi
+log "all assertions passed"

--- a/test-env/vm.sh
+++ b/test-env/vm.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# Control the pfSense test VM.
+#
+#   ./vm.sh start            boot the installed system
+#   ./vm.sh start install    boot the memstick installer instead
+#   ./vm.sh stop             ask pfSense to shut down, and wait for it
+#   ./vm.sh kill             terminate QEMU without a clean shutdown
+#   ./vm.sh status           is it running, and are its ports listening
+#   ./vm.sh snapshot [tag]   save a live snapshot, default tag "clean"
+#   ./vm.sh reset [tag]      roll back to a snapshot, about a second
+#   ./vm.sh monitor <cmd>    send a raw command to the QEMU monitor
+#
+# Networking is QEMU user-mode (slirp) on both NICs, so this needs no bridge, no
+# tap device and no root. em0 is WAN and reaches the internet, which the REST API
+# package install needs. em1 is LAN at a fixed address.
+#
+# Forwards bind to 127.0.0.1 only. This VM keeps pfSense's default credentials,
+# so binding to 0.0.0.0 would publish its webGUI and SSH to the whole physical
+# network.
+#
+#   127.0.0.1:8443   -> 443  webGUI and REST API
+#   127.0.0.1:2222   -> 22   SSH
+#   127.0.0.1:15353  -> 53   unbound, for checking that aliases resolve
+#
+# Containers cannot use these directly. A hostfwd rule bound to the Docker
+# bridge address accepts the TCP connection and then carries no data, so the
+# client sees a connect that succeeds followed by a read timeout. Run relay.sh
+# to publish the API to containers.
+set -euo pipefail
+
+# shellcheck source=lib/common.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib/common.sh"
+
+DISK="$LAB_DIR/pfsense.qcow2"
+STICK="$LAB_DIR/$PFSENSE_IMAGE"
+PIDFILE="$LAB_DIR/qemu.pid"
+
+vm_pid() { [[ -f "$PIDFILE" ]] && cat "$PIDFILE"; }
+
+vm_running() {
+  local pid
+  pid="$(vm_pid || true)"
+  [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null
+}
+
+monitor() {
+  vm_running || die "VM is not running"
+  printf '%s\n' "$*" | socat - "UNIX-CONNECT:$LAB_DIR/monitor.sock" | sed -n '3,$p'
+}
+
+start_console() {
+  # One long-lived process owns the serial socket, logging everything it prints
+  # and forwarding anything written to the FIFO. QEMU's chardev accepts a single
+  # client, so nothing else may connect while this runs.
+  pgrep -f "[c]onmux.py $LAB_DIR" >/dev/null && return 0
+  ( setsid nohup python3 "$TEST_ENV_DIR/lib/conmux.py" \
+      "$LAB_DIR/console.sock" "$LAB_DIR/console.log" "$LAB_DIR/console.fifo" \
+      >"$LAB_DIR/conmux.log" 2>&1 & )
+  sleep 2
+}
+
+stop_console() {
+  pkill -f "[c]onmux.py $LAB_DIR" 2>/dev/null || true
+}
+
+start() {
+  vm_running && { log "VM already running (pid $(vm_pid))"; return 0; }
+  [[ -f "$DISK" ]] || die "no disk at $DISK — run ./bootstrap.sh first"
+
+  # shellcheck disable=SC2054  # QEMU options carry commas inside single arguments
+  local args=(
+    -name pfsense-lab
+    -machine q35,accel=kvm
+    -cpu host
+    -smp 2
+    -m 4096
+    -display none
+    -vga none
+
+    -drive "file=$DISK,if=none,id=hd0,format=qcow2,cache=writeback"
+    -device virtio-blk-pci,drive=hd0,bootindex=1
+
+    -netdev user,id=wan,net=10.0.2.0/24,dhcpstart=10.0.2.15
+    -device e1000,netdev=wan
+
+    -netdev "user,id=lan,net=10.0.3.0/24,dhcpstart=10.0.3.20,hostfwd=tcp:127.0.0.1:${API_PORT}-${LAN_IP}:443,hostfwd=tcp:127.0.0.1:${SSH_PORT}-${LAN_IP}:22,hostfwd=udp:127.0.0.1:${DNS_PORT}-${LAN_IP}:53"
+    -device e1000,netdev=lan
+
+    -serial "unix:$LAB_DIR/console.sock,server=on,wait=off"
+    -monitor "unix:$LAB_DIR/monitor.sock,server=on,wait=off"
+    -pidfile "$PIDFILE"
+    -daemonize
+  )
+
+  if [[ "${1:-}" == "install" ]]; then
+    # The installer is attached over SATA rather than USB. Under qemu-xhci the
+    # memstick image throws persistent da0 read errors and the boot stalls
+    # retrying them. SATA also keeps the installer (ada0) and the target disk
+    # (vtbd0) on separate buses, so removing the installer afterwards cannot
+    # renumber the target.
+    # shellcheck disable=SC2054  # as above
+    args+=(
+      -drive "file=$STICK,if=none,id=stick,format=raw"
+      -device ide-hd,drive=stick,bootindex=0
+    )
+  fi
+
+  rm -f "$LAB_DIR/console.sock" "$LAB_DIR/monitor.sock" "$PIDFILE"
+  kvm_run qemu-system-x86_64 "${args[@]}"
+  sleep 2
+  start_console
+  log "VM started (pid $(vm_pid))"
+}
+
+stop() {
+  if ! vm_running; then
+    log "VM is not running"
+    stop_console
+    return 0
+  fi
+  log "asking pfSense to shut down"
+  "$TEST_ENV_DIR/pf.sh" 'nohup shutdown -p +1s >/dev/null 2>&1 &' >/dev/null 2>&1 || true
+  local waited=0
+  while vm_running && (( waited < 120 )); do
+    sleep 3
+    waited=$(( waited + 3 ))
+  done
+  if vm_running; then
+    warn "clean shutdown timed out; terminating QEMU"
+    kill "$(vm_pid)" 2>/dev/null || true
+    sleep 3
+  fi
+  stop_console
+  log "VM stopped"
+}
+
+case "${1:-status}" in
+  start)    start "${2:-}" ;;
+  stop)     stop ;;
+  kill)     kill "$(vm_pid)" 2>/dev/null || true; stop_console; log "VM killed" ;;
+  status)
+    if vm_running; then
+      log "VM running (pid $(vm_pid))"
+      ss -ltn 2>/dev/null | grep -E ":(${API_PORT}|${SSH_PORT})\b" || true
+    else
+      log "VM not running"
+    fi
+    ;;
+  snapshot) monitor savevm "${2:-clean}"; log "snapshot '${2:-clean}' saved" ;;
+  reset)    monitor loadvm "${2:-clean}"; log "rolled back to '${2:-clean}'" ;;
+  monitor)  shift; monitor "$@" ;;
+  *)        die "usage: $0 {start [install]|stop|kill|status|snapshot [tag]|reset [tag]|monitor <cmd>}" ;;
+esac


### PR DESCRIPTION
## What this adds

**`test-env/`** — a scripted, throwaway pfSense VM for testing changes against a real firewall.

```bash
test-env/bootstrap.sh    # nothing to a working pfSense, unattended, ~10 min
test-env/smoke.sh        # run the service against it and assert end to end
```

`bootstrap.sh` checks the host, downloads and checksums the installer image, drives the installer over a serial console, configures the LAN, installs the pfRest package, creates an API key, whitelists the gateway from pfSense's login protection, creates the parent host override this service expects, and takes a snapshot. `smoke.sh` then asserts the alias is created, resolves to the right address through the firewall's own resolver, disappears when the container stops, and that the service is still running afterwards. `vm.sh reset` rolls back to the snapshot in about a second.

**`CONTRIBUTING.md`** — human-facing contributor guide: setup, the checks that must pass, branching and PR rules, the test-ownership rule, and when to reach for the VM. It cross-references `AGENTS.md` rather than restating it.

## Why

The unit suite stubs both Docker and the pfSense API. That is what makes it fast and precise, but it means it can only confirm the client matches *our own idea* of the API. It cannot tell you whether a payload field lands where pfSense reads it, or whether a name actually resolves after an apply.

Both of those questions were already open, and both are now settled:

- **The `descr` payload key is correct.** The API field is `descr`; pfRest writes it into `config.xml` as `description`, which is the key the webGUI renders. Descriptions have always landed. `smoke.sh` asserts the round trip.
- **The escaping asymmetry in `AGENTS.md` holds on a live 2.7.2.** `$alias['host']` and `$alias['domain']` are echoed unescaped; `$alias['description']` goes through `htmlspecialchars()`.

## A limitation this surfaced

`pfsense.dns.remove_on_stop=true` does not combine reliably with `docker run --rm`. The stop handler reads a container's labels back from Docker, and Docker may already have deleted a container started with `--rm`. One container stopping alone is usually fine; twenty stopping together left 19 aliases orphaned.

Documented in `README.md` and `test-env/README.md`, **not fixed here**. The fix — caching alias configuration at start and using it on stop — adds module-level state that has to survive the repeated re-import in `tests/test_main.py`, so it deserves its own review rather than riding along with a docs change.

## Notes

- Nothing here runs in CI. It needs KVM, which GitHub's runners do not provide.
- No production code changed. `main.py` and `pfsense.py` are untouched.
- VM state lives outside the working tree, under `~/.local/share/pfsense-docker-alias-lab` by default (`PFSENSE_LAB_DIR` overrides). `test-env/` is added to `.dockerignore`; the build context is still 253 bytes.

## Verification

Deleted the hand-built VM and ran `bootstrap.sh` from scratch, then `smoke.sh`, then `smoke.sh --reset`, then a stop and restart to confirm the SSH key survives a reboot. All passed. `shellcheck -x` is clean on every script; pylint is still 10.00/10, 133 tests pass, coverage 98.93%, and `docker build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)