### PR TITLE
Remove a container's alias even when Docker deleted it first

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,7 @@ Expect start/stop to be detected, three retries per API call, an error log, and 
 
 `test-env/bootstrap.sh` builds a throwaway pfSense VM with the REST API package installed (about ten minutes and 6 GB of disk, entirely outside the working tree), and `test-env/smoke.sh` runs the service against it and asserts the whole path: alias created, resolving through the firewall's own resolver, removed on stop, service still alive. `test-env/vm.sh reset` rolls back to a clean snapshot in about a second. `test-env/README.md` is the reference; `CONTRIBUTING.md` says when to reach for it.
 
-This needs KVM, so it cannot run on GitHub's runners and is not part of CI. Run it by hand for any change touching `pfsense.py`, the apply/coalescing logic, or what goes into an API payload. The unit suite stubs both Docker and the API, so it can only confirm the client matches *our own idea* of the API — it cannot tell you whether a field lands where pfSense reads it, or whether a name resolves afterwards. Both of those questions have already been settled here in ways the suite could not have reached: the alias description really does arrive (the API's `descr` is written to `config.xml` as `description`, which is the key the webGUI renders), and `--rm` containers can lose their alias removal entirely, because the stop handler reads labels back from a container Docker has already deleted.
+This needs KVM, so it cannot run on GitHub's runners and is not part of CI. Run it by hand for any change touching `pfsense.py`, the apply/coalescing logic, or what goes into an API payload. The unit suite stubs both Docker and the API, so it can only confirm the client matches *our own idea* of the API — it cannot tell you whether a field lands where pfSense reads it, or whether a name resolves afterwards. Two things were settled here that the suite could not have reached: the alias description really does arrive (the API's `descr` is written to `config.xml` as `description`, which is the key the webGUI renders), and stopping twenty `--rm` containers at once orphaned nineteen aliases, which is the finding behind "A stopping container may already be gone" below.
 
 Two things about that environment are worth knowing before using it. Every request from the host reaches pfSense from one address, so its brute-force protection can blackhole SSH, the webGUI and the REST API simultaneously while the serial console still looks healthy — `bootstrap.sh` whitelists it, but suspect it first if everything goes quiet at once. And containers cannot reach the VM through QEMU's port forwarding directly; `test-env/relay.sh` bridges that gap.
 
@@ -114,6 +114,22 @@ The same burst arrives through the event loop — a `docker compose up` of twent
 Coalescing state (`PENDING_CHANGES`, `PENDING_SINCE`, `LAST_CHANGE_AT`, `LAST_APPLY_AT`) is module level and measured with `time.monotonic()`, so a wall-clock adjustment cannot strand pending changes. Note that `LAST_APPLY_AT = 0.0` reads as *long ago*, not *just now* — tests that need "an apply just happened" must set `time.monotonic()`.
 
 **`cleanup()` flushes before exit.** A SIGTERM with staged changes would otherwise leave them in the config but never live. It guards on `NAMESERVER is not None`, since a signal can arrive before `main()` constructs it, and swallows flush errors so a broken apply cannot block shutdown. Docker's default 10s stop grace can still cut a slow apply short; the changes stay staged and go live on the next apply.
+
+### A stopping container may already be gone
+
+`handle_container_event` cannot rely on reading a stopping container's labels back from Docker. A container run with `docker run --rm` is deleted as it stops, and Docker frequently wins that race: `client.containers.get` raises `NotFound`, and the handler used to log "Container not found" and return, leaving the alias in pfSense. Measured against the test VM, one such container stopping alone was usually fine and **twenty stopping together orphaned nineteen aliases**. The unit suite could not see this at all, because it stubs the Docker client so the lookup always succeeds.
+
+So `remember_alias_config()` records `(container_name, alias_config)` in `KNOWN_ALIASES`, keyed by container ID, whenever a start event is handled — and in `add_aliases_on_startup`, which is the only chance to record a container that was already running when this service started. On `NotFound`, `recall_alias_config()` supplies the fallback and the removal proceeds. When nothing was recorded, the original warning still fires.
+
+Three properties are deliberate:
+
+- **Only a stop is answered from the record.** `recall_alias_config` returns `None` for any action other than `stop`/`die`. A start event for a container that has already gone is genuinely nothing to act on, and treating it as a removal would delete an alias in response to the wrong event.
+- **The `remove_on_stop` opt-in still applies.** The recorded configuration is checked the same way a live label read would be, so falling back never removes an alias the labels did not ask to remove.
+- **Entries are not dropped on stop.** Docker emits both `die` and `stop` for one shutdown, and the second event must reach the same answer as the first. Removing the entry on the first would make the second log "Container not found" for a container that was handled correctly a moment earlier.
+
+That last choice means container IDs — which are never reused — would accumulate for the life of the process, so `KNOWN_ALIASES_MAX` (512) bounds the table and the oldest entry is evicted on overflow. Eviction relies on dictionaries preserving insertion order; `remember_alias_config` deletes before reinserting so a re-recorded container counts as newest. The second removal attempt costs one API call and no extra apply: `del_host_override_alias` returns `False` without mutating when the alias is already absent, so `unapplied_changes` stays clear and `_record_change_outcome` does nothing.
+
+This is bounded, not unlimited memory: a container that starts, is recorded, and stops more than 512 container-starts later has been evicted, and its `--rm` removal fails the old way. Raising the cap trades memory for that window.
 
 ### The event loop yields window ticks
 

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ services:
 - Replace `caddy.lab.internal` with the fully qualified hostname of your reverse proxy. Make sure it exists as a host override in pfSense.
 - Replace `nginx.lab.internal` with the fully qualified hostname of the service you're deploying.
 - An alias longer than 253 characters is rejected with a warning and cannot be resolved by DNS anyway. If one already exists in pfSense from an earlier version of this service, remove it in the webGUI — this service will decline to touch it.
-- `pfsense.dns.remove_on_stop=true` does not combine reliably with `docker run --rm`. This service reads a stopping container's labels back from Docker, and Docker may already have deleted a container started with `--rm`, in which case the alias is left behind. A single container stopping on its own is usually fine; a batch stopping together is not. Prefer `docker compose` or a container without `--rm` when you rely on removal.
+- `pfsense.dns.remove_on_stop=true` works with `docker run --rm`. This service records a container's alias configuration when it starts, so a container Docker has already deleted by the time its stop event arrives still has its alias removed. Containers already running before this service starts are only recorded when `ADD_ALIASES_ON_STARTUP` is enabled; without it, a pre-existing `--rm` container that stops may leave its alias behind.
 
 ## Contributing 💻
 

--- a/main.py
+++ b/main.py
@@ -87,6 +87,18 @@ PENDING_SINCE = None
 LAST_CHANGE_AT = None
 LAST_APPLY_AT = None
 
+# Alias configuration recorded when a container is first seen, keyed by container ID.
+# Handling a stop used to depend on reading the container's labels back from Docker,
+# which fails for a container run with `docker run --rm`: Docker can delete it before
+# the stop event is handled, and the alias was then left behind. Twenty such containers
+# stopped together left nineteen aliases orphaned.
+KNOWN_ALIASES = {}
+# Container IDs are never reused, so nothing here can be evicted by a later start of
+# the same container and the table would otherwise grow for the life of the process.
+# Entries are also deliberately not dropped on stop: Docker sends both `die` and `stop`
+# for one shutdown, and the second event must find the same answer as the first.
+KNOWN_ALIASES_MAX = 512
+
 # Initialize Docker client
 try:
     client = docker.from_env()
@@ -120,6 +132,9 @@ def add_aliases_on_startup():
             continue
 
         labeled += 1
+        # A container already running when this service starts never produces a start
+        # event, so this scan is the only chance to record it for a later stop.
+        remember_alias_config(container.id, container.name, alias_config)
         logger.info(
             f"Staging alias '{pfsense.sanitize_for_log(alias_config['alias_fqdn'])}' "
             f"for container '{pfsense.sanitize_for_log(container.name)}'"
@@ -208,6 +223,40 @@ def get_alias_event_action(event_action, labels):
 
     return None
 
+def remember_alias_config(container_id, container_name, alias_config):
+    """Record a container's alias configuration so a later stop does not need Docker."""
+    KNOWN_ALIASES.pop(container_id, None)
+    KNOWN_ALIASES[container_id] = (container_name, alias_config)
+    while len(KNOWN_ALIASES) > KNOWN_ALIASES_MAX:
+        # Dictionaries keep insertion order, so the first key is the oldest entry.
+        KNOWN_ALIASES.pop(next(iter(KNOWN_ALIASES)))
+
+def recall_alias_config(container_id, event_action):
+    """
+    Alias configuration recorded for a container Docker can no longer describe.
+
+    Only a stop is answered from the record. A start event for a container that has
+    already gone is genuinely nothing to act on, and treating it as a removal would
+    delete an alias in response to the wrong event.
+    """
+    if event_action not in ['stop', 'die']:
+        return None
+
+    remembered = KNOWN_ALIASES.get(container_id)
+    if remembered is None:
+        return None
+
+    _container_name, alias_config = remembered
+    if not alias_config["remove_on_stop"]:
+        return None
+
+    return remembered
+
+def _remove_alias_for(container_name, alias_config):
+    """Log and dispatch the removal of a stopping container's alias."""
+    logger.info(f"Container '{pfsense.sanitize_for_log(container_name)}' is stopping...")
+    process_stop_event(alias_config["host_override_fqdn"], alias_config["alias_fqdn"])
+
 def handle_container_event(event):
     """Handle a Docker container start/stop event."""
     container_id = event.get('Actor', {}).get('ID')
@@ -215,10 +264,19 @@ def handle_container_event(event):
         logger.warning("Ignoring container event with missing container ID.")
         return
 
+    event_action = event.get('Action')
+
     try:
         container = client.containers.get(container_id)
     except docker.errors.NotFound as e:
-        logger.warning(f"Container not found: {pfsense.sanitize_for_log(e)}")
+        # Expected for a container run with `--rm`, which Docker may delete before this
+        # event is handled. Its labels are unreadable now, so fall back to what was
+        # recorded when it started rather than leaving the alias behind.
+        remembered = recall_alias_config(container_id, event_action)
+        if remembered is None:
+            logger.warning(f"Container not found: {pfsense.sanitize_for_log(e)}")
+            return
+        _remove_alias_for(*remembered)
         return
     except docker.errors.DockerException as e:
         _handle_error(e, "handle_container_event")
@@ -226,13 +284,14 @@ def handle_container_event(event):
 
     labels = get_container_labels(container)
 
-    alias_action = get_alias_event_action(event.get('Action'), labels)
+    alias_action = get_alias_event_action(event_action, labels)
     if not alias_action:
         return
 
     action, alias_config = alias_action
 
     if action == "add":
+        remember_alias_config(container_id, container.name, alias_config)
         logger.info(f"Container '{pfsense.sanitize_for_log(container.name)}' is starting...")
         process_start_event(
             alias_config["host_override_fqdn"],
@@ -240,8 +299,7 @@ def handle_container_event(event):
             alias_config["alias_descr"]
         )
     elif action == "remove":
-        logger.info(f"Container '{pfsense.sanitize_for_log(container.name)}' is stopping...")
-        process_stop_event(alias_config["host_override_fqdn"], alias_config["alias_fqdn"])
+        _remove_alias_for(container.name, alias_config)
 
 def should_apply_immediately():
     """

--- a/test-env/README.md
+++ b/test-env/README.md
@@ -102,12 +102,12 @@ off pfRest's own login protection. If you still manage to trip it:
 PFSENSE_LAB_DIR=... python3 test-env/lib/sendkeys.py "pfctl -t sshguard -T flush{ENTER}"
 ```
 
-**`--rm` and `remove_on_stop` do not reliably combine.** The service reads a
-stopping container's labels back from the Docker API, and Docker may have
-already deleted a container started with `--rm`. One container stopped on its
-own is usually fine; twenty stopped at once left 19 aliases orphaned. This is a
-property of the service, not of the test environment — `smoke.sh` avoids `--rm`
-deliberately.
+**`--rm` containers were the first real bug this environment found.** Docker can
+delete a container started with `--rm` before its stop event is handled, so its
+labels are unreadable and the alias was left behind: twenty stopped at once
+orphaned nineteen aliases. The service now records alias configuration at start
+and falls back to it, and `smoke.sh` asserts both paths — a container whose
+labels are still readable, and one Docker has already deleted.
 
 **Arrow keys cancel installer dialogs.** Over this serial console `dialog(1)`
 reads the leading ESC of `ESC [ B` as a bare escape and treats it as cancel,

--- a/test-env/smoke.sh
+++ b/test-env/smoke.sh
@@ -19,7 +19,9 @@ source "$(dirname "${BASH_SOURCE[0]}")/lib/common.sh"
 REPO_DIR="$(cd "$TEST_ENV_DIR/.." && pwd)"
 SERVICE="smoke-alias-service"
 TARGET="smoke-target"
+EPHEMERAL="smoke-ephemeral"
 ALIAS_NAME="smoke.$PARENT_DOMAIN"
+EPHEMERAL_ALIAS="ephemeral.$PARENT_DOMAIN"
 DESCRIPTION="set by smoke.sh"
 IMAGE="pfsense-docker-alias:smoke"
 
@@ -29,13 +31,14 @@ pass() { printf '  \033[32mok\033[0m   %s\n' "$*"; }
 fail() { printf '  \033[31mFAIL\033[0m %s\n' "$*"; FAILURES=$(( FAILURES + 1 )); }
 
 cleanup() {
-  docker rm -f "$SERVICE" "$TARGET" >/dev/null 2>&1 || true
+  docker rm -f "$SERVICE" "$TARGET" "$EPHEMERAL" >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
 
 resolves()     { [[ -n "$(dig +short +timeout=3 "@127.0.0.1" -p "$DNS_PORT" "$1" 2>/dev/null)" ]]; }
 not_resolves() { ! resolves "$1"; }
 logged()       { docker logs "$SERVICE" 2>&1 | grep -q "$1"; }
+container_gone() { ! docker inspect "$1" >/dev/null 2>&1; }
 
 # assert_within DESCRIPTION TIMEOUT PREDICATE [ARGS...]
 #
@@ -87,8 +90,8 @@ assert_within "the service reaches its event loop" 60 logged "Listening for cont
 # --------------------------------------------------------------------------
 log "a labelled container should create an alias that resolves"
 
-# Deliberately not --rm. A container Docker has already deleted cannot have its
-# labels read back when it stops, so its alias is left behind; see the README.
+# Deliberately not --rm: this is the path where the container is still there when it
+# stops and its labels can be read back. The --rm case is exercised separately below.
 docker run -d --name "$TARGET" \
   -l "pfsense.dns.override=$PARENT_HOST.$PARENT_DOMAIN" \
   -l "pfsense.dns.alias=$ALIAS_NAME" \
@@ -126,6 +129,30 @@ docker stop "$TARGET" >/dev/null
 
 assert_within "the service logs the alias as removed" 120 logged "$ALIAS_NAME removed"
 assert_within "$ALIAS_NAME stops resolving" 120 not_resolves "$ALIAS_NAME"
+
+# --------------------------------------------------------------------------
+log "a --rm container should lose its alias too, though Docker deletes it first"
+
+# The regression that motivated recording alias configuration at start: Docker
+# removes this container as it stops, so its labels cannot be read back and the
+# removal has to come from what was recorded when it started.
+#
+# Treat this as a live sanity check rather than the regression guard. A single
+# --rm container often used to be removed correctly anyway, because the service
+# sometimes won the race to read the labels; it took a batch stopping together to
+# lose them reliably. The deterministic guard is
+# tests/test_main.py::test_a_burst_of_deleted_containers_removes_every_alias.
+docker run -d --rm --name "$EPHEMERAL" \
+  -l "pfsense.dns.override=$PARENT_HOST.$PARENT_DOMAIN" \
+  -l "pfsense.dns.alias=$EPHEMERAL_ALIAS" \
+  -l "pfsense.dns.remove_on_stop=true" \
+  alpine sleep 600 >/dev/null
+
+assert_within "$EPHEMERAL_ALIAS resolves" 120 resolves "$EPHEMERAL_ALIAS"
+
+docker stop "$EPHEMERAL" >/dev/null
+assert_within "the container is really gone" 60 container_gone "$EPHEMERAL"
+assert_within "$EPHEMERAL_ALIAS stops resolving anyway" 120 not_resolves "$EPHEMERAL_ALIAS"
 
 # --------------------------------------------------------------------------
 log "the service should still be running"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -250,6 +250,7 @@ def test_add_aliases_on_startup_adds_labeled_running_containers(monkeypatch):
     calls = []
     fake_client.containers.list = lambda: [
         types.SimpleNamespace(
+            id="id-nginx",
             name="nginx",
             attrs={
                 "Config": {
@@ -261,7 +262,9 @@ def test_add_aliases_on_startup_adds_labeled_running_containers(monkeypatch):
                 }
             },
         ),
-        types.SimpleNamespace(name="unlabeled", attrs={"Config": {"Labels": {}}}),
+        types.SimpleNamespace(
+            id="id-unlabeled", name="unlabeled", attrs={"Config": {"Labels": {}}}
+        ),
     ]
     applies = []
     main.NAMESERVER = types.SimpleNamespace(
@@ -602,6 +605,7 @@ def test_main_runs_startup_scan_only_when_enabled(monkeypatch):
 
 def _labeled_container(name, alias):
     return types.SimpleNamespace(
+        id=f"id-{name}",
         name=name,
         attrs={
             "Config": {
@@ -1264,3 +1268,181 @@ def test_docker_client_init_failure_log_cannot_forge_a_log_record(monkeypatch, c
     assert "boom" in critical[0]
     assert "forged" in critical[0]
     assert "Error initializing Docker client" in caplog.text
+
+
+# --- Remembering aliases so a deleted container can still be cleaned up -------
+
+
+def _remembering_container(container_id, name, alias, remove_on_stop=True):
+    labels = {
+        "pfsense.dns.override": "caddy.lab.internal",
+        "pfsense.dns.alias": alias,
+    }
+    if remove_on_stop:
+        labels["pfsense.dns.remove_on_stop"] = "true"
+    return types.SimpleNamespace(
+        id=container_id,
+        name=name,
+        attrs={"Config": {"Labels": labels}},
+    )
+
+
+def _container_is_gone(fake_client):
+    def gone(_container_id):
+        raise DockerNotFound("no such container")
+
+    fake_client.containers.get = gone
+
+
+def test_a_deleted_container_still_loses_its_alias_on_stop(monkeypatch):
+    """
+    A container run with `docker run --rm` is often deleted before its stop event is
+    handled, so its labels can no longer be read back from Docker. The alias must
+    still be removed, from what was recorded when the container started.
+    """
+    main, fake_client = load_main(monkeypatch)
+    removals = []
+    monkeypatch.setattr(main, "process_start_event", lambda *_args: None)
+    monkeypatch.setattr(
+        main,
+        "process_stop_event",
+        lambda host_override, alias: removals.append((host_override, alias)),
+    )
+
+    fake_client.container = _remembering_container("abc123", "nginx", "nginx.lab.internal")
+    main.handle_container_event({"Actor": {"ID": "abc123"}, "Action": "start"})
+
+    _container_is_gone(fake_client)
+    main.handle_container_event({"Actor": {"ID": "abc123"}, "Action": "stop"})
+
+    assert removals == [("caddy.lab.internal", "nginx.lab.internal")]
+
+
+def test_a_burst_of_deleted_containers_removes_every_alias(monkeypatch):
+    """
+    The regression this exists for. Twenty `--rm` containers stopped together left
+    nineteen aliases behind against a real pfSense, because Docker won the race to
+    delete each container before its stop event was handled.
+    """
+    main, fake_client = load_main(monkeypatch)
+    monkeypatch.setattr(main, "process_start_event", lambda *_args: None)
+    removals = []
+    monkeypatch.setattr(
+        main, "process_stop_event", lambda _host_override, alias: removals.append(alias)
+    )
+
+    for index in range(20):
+        fake_client.container = _remembering_container(
+            f"id-{index}", f"svc{index}", f"svc{index}.lab.internal"
+        )
+        main.handle_container_event({"Actor": {"ID": f"id-{index}"}, "Action": "start"})
+
+    _container_is_gone(fake_client)
+    for index in range(20):
+        main.handle_container_event({"Actor": {"ID": f"id-{index}"}, "Action": "stop"})
+
+    assert removals == [f"svc{index}.lab.internal" for index in range(20)]
+
+
+def test_a_container_never_seen_starting_still_reports_not_found(monkeypatch, caplog):
+    """Nothing was recorded, so there is nothing to fall back to — say so and move on."""
+    main, fake_client = load_main(monkeypatch)
+    removals = []
+    monkeypatch.setattr(
+        main, "process_stop_event", lambda host_override, alias: removals.append((host_override, alias))
+    )
+    _container_is_gone(fake_client)
+
+    with caplog.at_level(logging.WARNING):
+        main.handle_container_event({"Actor": {"ID": "never-seen"}, "Action": "stop"})
+
+    assert removals == []
+    assert "Container not found" in caplog.text
+
+
+def test_a_deleted_container_without_remove_on_stop_keeps_its_alias(monkeypatch, caplog):
+    """Falling back to a recorded configuration must still honour the opt-in label."""
+    main, fake_client = load_main(monkeypatch)
+    removals = []
+    monkeypatch.setattr(main, "process_start_event", lambda *_args: None)
+    monkeypatch.setattr(
+        main, "process_stop_event", lambda host_override, alias: removals.append((host_override, alias))
+    )
+
+    fake_client.container = _remembering_container(
+        "abc123", "nginx", "nginx.lab.internal", remove_on_stop=False
+    )
+    main.handle_container_event({"Actor": {"ID": "abc123"}, "Action": "start"})
+
+    _container_is_gone(fake_client)
+    with caplog.at_level(logging.WARNING):
+        main.handle_container_event({"Actor": {"ID": "abc123"}, "Action": "stop"})
+
+    assert removals == []
+    assert "Container not found" in caplog.text
+
+
+def test_a_missing_container_on_a_start_event_is_not_treated_as_a_stop(monkeypatch, caplog):
+    """A recorded alias is a fallback for stopping, never a reason to remove on start."""
+    main, fake_client = load_main(monkeypatch)
+    removals = []
+    monkeypatch.setattr(main, "process_start_event", lambda *_args: None)
+    monkeypatch.setattr(
+        main, "process_stop_event", lambda host_override, alias: removals.append((host_override, alias))
+    )
+
+    fake_client.container = _remembering_container("abc123", "nginx", "nginx.lab.internal")
+    main.handle_container_event({"Actor": {"ID": "abc123"}, "Action": "start"})
+
+    _container_is_gone(fake_client)
+    with caplog.at_level(logging.WARNING):
+        main.handle_container_event({"Actor": {"ID": "abc123"}, "Action": "start"})
+
+    assert removals == []
+    assert "Container not found" in caplog.text
+
+
+def test_the_remembered_alias_table_is_bounded(monkeypatch):
+    """
+    Container IDs are never reused, so entries would otherwise accumulate for the
+    lifetime of the process. The oldest are dropped once the table is full.
+    """
+    main, fake_client = load_main(monkeypatch)
+    monkeypatch.setattr(main, "process_start_event", lambda *_args: None)
+
+    overflow = main.KNOWN_ALIASES_MAX + 5
+    for index in range(overflow):
+        fake_client.container = _remembering_container(
+            f"id-{index}", f"svc{index}", f"svc{index}.lab.internal"
+        )
+        main.handle_container_event({"Actor": {"ID": f"id-{index}"}, "Action": "start"})
+
+    assert len(main.KNOWN_ALIASES) == main.KNOWN_ALIASES_MAX
+    assert "id-0" not in main.KNOWN_ALIASES
+    assert f"id-{overflow - 1}" in main.KNOWN_ALIASES
+
+
+def test_startup_scan_remembers_aliases_for_containers_it_did_not_see_start(monkeypatch):
+    """
+    A container already running when this service starts never produces a start event,
+    so the startup scan is the only chance to record it.
+    """
+    main, fake_client = load_main(monkeypatch)
+    fake_client.containers.list = lambda: [
+        _remembering_container("abc123", "nginx", "nginx.lab.internal")
+    ]
+    main.NAMESERVER = types.SimpleNamespace(
+        add_host_override_alias=lambda *_args, **_kwargs: True,
+        apply_changes=lambda: True,
+    )
+    main.add_aliases_on_startup()
+
+    removals = []
+    monkeypatch.setattr(
+        main, "process_stop_event", lambda host_override, alias: removals.append((host_override, alias))
+    )
+    _container_is_gone(fake_client)
+
+    main.handle_container_event({"Actor": {"ID": "abc123"}, "Action": "stop"})
+
+    assert removals == [("caddy.lab.internal", "nginx.lab.internal")]


### PR DESCRIPTION
Fixes the `--rm` limitation documented in #16.

## The bug

`handle_container_event` read a stopping container's labels back from Docker as its only source of truth. A container run with `docker run --rm` is deleted as it stops, and Docker often wins that race — the lookup raised `NotFound`, the handler logged `Container not found` and returned, and the alias stayed in pfSense.

Measured against the test environment from #16:

| | aliases orphaned |
|---|---|
| one `--rm` container stopping alone | usually 0 — the service often won the race |
| twenty stopping together | **19 of 20** |

The unit suite could not see any of this. It stubs the Docker client, so the label lookup always succeeds and the race does not exist.

## The fix

`remember_alias_config()` records `(container_name, alias_config)` keyed by container ID whenever a start event is handled, and in `add_aliases_on_startup` — the only chance to record a container that was already running when the service started. On `NotFound`, `recall_alias_config()` supplies the fallback. When nothing was recorded, the original warning still fires unchanged.

Three limits are deliberate, and each has a test:

- **Only `stop` and `die` are answered from the record.** A start event for a container that has already gone is nothing to act on; treating it as a removal would delete an alias in response to the wrong event.
- **`remove_on_stop` is still honoured.** Falling back cannot remove an alias the labels did not ask to remove.
- **Entries are not dropped on stop.** Docker emits both `die` and `stop` for one shutdown, and the second event must reach the same answer as the first. Dropping on the first would make the second log `Container not found` for a container handled correctly a moment earlier.

That last choice means container IDs — never reused — would accumulate for the life of the process, so `KNOWN_ALIASES_MAX` (512) bounds the table and evicts the oldest entry. The second removal attempt costs one API call and no extra apply: `del_host_override_alias` returns `False` without mutating when the alias is already absent, so `unapplied_changes` stays clear.

This is bounded, not unlimited. A container evicted before it stops fails the old way, and `AGENTS.md` says so.

## Verification

Against the live pfSense VM, the exact scenario that failed:

```
started 20 --rm containers
aliases created: 20
stopped all 20 at once
aliases remaining after 10s: 0     # previously 19
```

`smoke.sh` gains a `--rm` phase that asserts the container is really gone and the alias stops resolving anyway. Treat that as a live sanity check, not the regression guard — a single `--rm` container often passed before this fix too, when the race went the other way. The deterministic guard is `test_a_burst_of_deleted_containers_removes_every_alias`.

Full `smoke.sh --reset` passes end to end. pylint 10.00/10, 140 tests pass (7 new), coverage 98.99%, `pip-audit --strict` clean, `docker build` fine, `shellcheck -x` clean.

## On the test changes

Seven new tests were written before the implementation, and all four that assert the new behaviour failed first for the right reason.

Fixtures for the startup scan gained an `id` field, because the new code reads `container.id` and every real Docker container object has one. That is a fixture gap being filled, not an assertion being softened — no existing assertion changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)