### PR TITLE
Cover the unreadable-CA-bundle startup check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ uv pip install -r requirements.txt -r requirements-dev.txt
 
 ```bash
 .venv/bin/python -m py_compile main.py pfsense.py   # required after changing either Python file
-.venv/bin/python -m pytest                          # full suite (133 tests)
+.venv/bin/python -m pytest                          # full suite (142 tests)
 .venv/bin/python -m pytest --cov --cov-report=term-missing   # with the coverage gate
 .venv/bin/python -m pytest tests/test_main.py::test_parse_alias_labels_returns_alias_config   # single test
 .venv/bin/python -m pylint main.py pfsense.py       # must stay at 10.00/10

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -407,6 +407,56 @@ def test_import_exits_when_docker_client_cannot_initialize(monkeypatch):
         sys.modules.pop("main", None)
 
 
+def test_import_exits_when_the_ca_bundle_is_not_readable(monkeypatch, caplog, tmp_path, capsys):
+    """
+    An unreadable PFSENSE_CA_BUNDLE must fail loudly at startup, not per request.
+
+    This path used to surface as an opaque crash loop out of `requests` — a bare
+    OSError on every call — which pushed operators toward turning TLS verification
+    off to get the service running. The message therefore has to name the path so
+    the fix is obvious. It is deliberately *not* sanitized: the value comes from
+    whoever configures the service, who already owns the process, so escaping it
+    would defend against nobody. See AGENTS.md, "Exclusions".
+    """
+    missing = tmp_path / "no-such-ca.pem"
+
+    with caplog.at_level(logging.CRITICAL):
+        try:
+            load_main(monkeypatch, ca_bundle=str(missing))
+        except SystemExit as exc:
+            assert exc.code == 1
+        else:
+            raise AssertionError("import did not exit")
+
+    critical = [m for m in log_messages(caplog) if "is not readable" in m]
+    assert len(critical) == 1
+    assert str(missing) in critical[0]
+    # The remedy belongs in the message; an operator seeing only "not readable" has
+    # no reason to suspect a missing bind mount.
+    assert "mounted into the container" in critical[0]
+    # Never print the token while reporting a configuration error.
+    assert "test-token" not in caplog.text
+    assert "test-token" not in capsys.readouterr().err
+
+
+def test_a_readable_ca_bundle_starts_normally(monkeypatch, tmp_path):
+    """
+    The startup check rejects an *unreadable* bundle, not the mere presence of one.
+
+    Without this, inverting the condition in main.py would still leave the test
+    above green while making every custom CA bundle fatal.
+    """
+    bundle = tmp_path / "ca.pem"
+    bundle.write_text("-- not a real certificate --\n")
+
+    main, _fake_client = load_main(monkeypatch, verify_ssl="false", ca_bundle=str(bundle))
+
+    assert main.PFSENSE_CA_BUNDLE == str(bundle)
+    # PFSENSE_CA_BUNDLE wins over PFSENSE_VERIFY_SSL: main passes both down and
+    # PFSense resolves the precedence, so main must not drop the bundle here.
+    assert main.PFSENSE_VERIFY_SSL is False
+
+
 def test_cleanup_closes_client_and_exits_zero(monkeypatch):
     main, fake_client = load_main(monkeypatch)
 


### PR DESCRIPTION
## What

Adds two tests for `main.py`'s `PFSENSE_CA_BUNDLE` readability check, and corrects a stale number in `AGENTS.md`. **No production code changes.**

## Why

This check has been the one genuinely uncovered path in the codebase since PR #12. It was recorded then as untestable "because it fires at import time before any test harness attaches" — that was wrong. `caplog` attaches to the root logger before the test body executes, so records emitted during an `importlib.import_module` call *inside* a test are captured like any other. `tests/test_main.py` already relies on this in `test_docker_client_init_failure_log_cannot_forge_a_log_record`. The path was simply never written.

The behavior is worth pinning rather than just covering. An unreadable CA bundle used to surface as a bare `OSError` out of `requests` on every request — an opaque crash loop that pushed operators toward disabling TLS verification to get the service running. Failing loudly at startup, with a message naming both the path and the likely cause, is the thing that prevents that.

## The tests

- `test_import_exits_when_the_ca_bundle_is_not_readable` — asserts `exit(1)`, exactly one critical record, that it names the offending path, that it names the remedy (a missing bind mount), and that the API token appears in neither the log nor stderr while a config error is being reported.
- `test_a_readable_ca_bundle_starts_normally` — asserts the check rejects an *unreadable* bundle, not the presence of one. Without it, inverting the condition would leave the first test green while making every custom CA bundle fatal.

The first test deliberately does **not** assert that the path is escaped. `PFSENSE_CA_BUNDLE` is supplied by whoever configures the service, who already owns the process, so it is one of the listed exclusions from the trust-boundary rule in `AGENTS.md`. Asserting escaping here would encode the opposite of the documented rule.

## Test ownership

I wrote these under `tests/` deliberately, as the point of the change, not to get an implementation to green — there is no implementation change to soften against. No existing assertion was modified or removed.

## Result

`main.py` now has **no uncovered statements**. Total coverage 98.99% → 99.50%, 142 tests. Two partial branches remain and are not addressed here: `main.py:301->exit` (`handle_container_event` falling past the `add`/`remove` cases) and `pfsense.py:222` (`_request`'s post-loop `return None`). Both are defensive; neither is a config path, and I left them rather than widen the scope.

## Checks

`py_compile`, `pylint` 10.00/10, `pip-audit --strict` on both requirements files, full suite with the coverage gate, and `docker build` all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)