### PR TITLE
Document the v0.2.0 breaking changes and make the TLS break self-diagnosing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,6 +204,8 @@ This no-op has a cost, and it is actionable rather than merely a lament: because
 
 Never log API tokens, secrets, full authorization headers, sensitive environment values, or API response bodies. `_handle_api_error` logs the exception and status code but not `response.text`, and `test_http_error_logs_status_without_response_body` enforces it.
 
+`_handle_api_error` also logs one extra line for a `requests.exceptions.SSLError`, naming `PFSENSE_CA_BUNDLE` and `PFSENSE_VERIFY_SSL`. This exists because verification defaults to on while this service's own `v0.1.x` never verified at all, so an upgrading operator meets a certificate error naming a setting they have no reason to know exists. Two properties are deliberate. The hint is **added to** the underlying error, never a replacement for it — the cause matters when the failure is expiry or a hostname mismatch rather than an untrusted issuer. And it keys on `SSLError` specifically, **not** its `ConnectionError` parent: advice to consider switching verification off must not print every time the firewall is briefly unreachable, which is how a fail-secure default gets disabled for an unrelated reason. `test_an_ordinary_connection_error_does_not_suggest_disabling_tls` pins that boundary; widening the check to `ConnectionError` fails it.
+
 ## Branching and pull requests
 
 `main` is protected: it takes no direct pushes. All work lands through a pull request that squash-merges into one commit, so `main` stays linear.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,113 @@
+# Changelog
+
+This project uses semantic versioning. It is still on `0.x`, which means a minor
+release may contain breaking changes — and `v0.2.0` does.
+
+## v0.2.0 — 2026-08-06
+
+The first release since `v0.1.2` (January 2025). Read the breaking changes before
+upgrading, especially if you pull the `latest` tag.
+
+### Breaking changes
+
+**1. TLS certificate verification is now on by default.**
+
+`v0.1.2` sent every request to pfSense with certificate verification disabled, with
+no way to turn it on. This release verifies by default. Most pfSense installations
+use a self-signed certificate, so if yours does, **every API call will fail after
+upgrading** until you choose one of the following.
+
+The failure is not silent. The service logs the underlying cause and then names both
+settings:
+
+```
+ERROR - API call failed during 'get_all_host_overrides': ... certificate verify failed: self-signed certificate
+ERROR - TLS certificate verification failed. Mount a CA bundle and set PFSENSE_CA_BUNDLE
+        to its path inside the container, or set PFSENSE_VERIFY_SSL=false to skip
+        verification entirely, which exposes the API token to anyone able to intercept
+        the connection.
+```
+
+To keep verification on — recommended — export your pfSense CA certificate, mount it,
+and point `PFSENSE_CA_BUNDLE` at it:
+
+```yaml
+environment:
+  PFSENSE_CA_BUNDLE: "/etc/ssl/certs/pfsense-ca.pem"
+volumes:
+  - ./pfsense-ca.pem:/etc/ssl/certs/pfsense-ca.pem:ro
+```
+
+To restore the old behaviour instead, set `PFSENSE_VERIFY_SSL=false`. This is what
+`v0.1.2` did on every request, but understand the trade: this service authenticates
+with a pfSense API token, so anyone able to intercept the connection can present any
+certificate and collect that token.
+
+**2. Alias and host override names are capped at 253 characters.**
+
+Names longer than RFC 1035's limit are now rejected with a warning instead of being
+sent to pfSense. Each dot-separated label is also capped at 63 characters and limited
+to letters, digits, and hyphens.
+
+If an over-long alias already exists in pfSense from an earlier version of this
+service, **delete it in the pfSense webGUI**, and do not wait. Such an entry is not
+harmless leftover config: it makes `unbound-checkconf` fail, so the DNS resolver stops
+on its next reload and every name on the firewall stops resolving. This service will
+not remove the entry for you, because the same length rule that blocks creating one
+also blocks removing it.
+
+### Added
+
+- `pfsense.dns.description` label, setting the alias description shown in the pfSense
+  webGUI. Unprintable characters become spaces and the value is capped at 255
+  characters.
+- `PFSENSE_VERIFY_SSL` (default `true`) and `PFSENSE_CA_BUNDLE` (default unset) to
+  control certificate verification. `PFSENSE_CA_BUNDLE` takes precedence. An
+  unreadable bundle now stops the service at startup with a clear message rather than
+  failing on every request.
+- `APPLY_QUIET_SECONDS` (default `10`) and `APPLY_MAX_WAIT_SECONDS` (default `60`) to
+  tune how container-event bursts are batched.
+
+### Fixed
+
+- **A container started with `docker run --rm` now loses its alias when it stops.**
+  Docker deletes such a container as it stops, and the service used to read its labels
+  back from Docker at that moment. It usually lost that race: twenty containers
+  stopping together left nineteen aliases behind. The alias configuration is now
+  recorded when the container starts.
+- **A burst of container events costs one resolver reload, not one per alias.** A
+  `docker compose up` of twenty labelled services previously triggered twenty unbound
+  reloads and roughly forty seconds of DNS disruption, with overlapping reloads a
+  likely source of dropped updates. It now costs two. A single container start still
+  applies immediately.
+- **The startup scan applies once** rather than once per alias found.
+- **A failed apply no longer strands changes.** A change that reached the pfSense
+  configuration while its apply failed used to be forgotten, so nothing retried it and
+  the alias never went live. Pending changes are now retried on a later event or at
+  shutdown.
+- **Applies are confirmed rather than assumed.** pfSense reloads asynchronously, so
+  the request returns before the reload finishes. The service now polls until pfSense
+  reports the change applied, and reports a failure if it never does.
+- **Failed API calls are retried** up to three times for network-level errors.
+- **A malformed or unexpected API response no longer stops the service.** An
+  unrecognised response body used to raise straight out of the pfSense client and exit
+  the container; it is now logged and skipped.
+- **Container labels can no longer forge log records.** Externally supplied values are
+  escaped before they reach a log message, so a newline in a label cannot fabricate a
+  log line. Values are also length-capped.
+- **A pfSense API error no longer logs the response body**, which could contain data
+  not intended for the log.
+- **The service survives a SIGTERM with work in flight**, flushing staged changes
+  before exit.
+
+### Changed
+
+- Base image moved from `python:3.12-alpine` to `python:3.14-alpine`.
+- Runtime dependencies updated; the pinned set is free of known CVEs as of this
+  release, and CI fails on any new advisory.
+- Added `CONTRIBUTING.md` and `test-env/`, which builds a throwaway pfSense VM so
+  changes can be tested end to end against a real firewall.
+
+## v0.1.2 and earlier
+
+Not documented here. See the commit history.

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ With **pfSense Docker Alias**, the **last step** is automated! Simply label your
 - **Startup Alias Sync**: Optionally scans currently running containers and ensures aliases are present in pfSense.
 - **Highly Configurable**: Flexible environment variables and Docker labels.
 - **Lightweight**: Built on an Alpine-based Python image for minimal resource usage.
-- **Secure**: Requires API key-based authentication for pfSense.
-- **Flexible**: Works with self-signed certificates for pfSense.
+- **Secure**: Requires API key-based authentication for pfSense, and verifies the pfSense certificate by default.
+- **Flexible**: Works with self-signed certificates for pfSense — mount your CA bundle and set `PFSENSE_CA_BUNDLE`, or turn verification off with `PFSENSE_VERIFY_SSL=false` if you cannot.
 
 ## Requirements 🛠️
 
@@ -53,6 +53,35 @@ With **pfSense Docker Alias**, the **last step** is automated! Simply label your
   Follow the installation instructions here: [Install and Configure the API](https://pfrest.org/INSTALL_AND_CONFIG/)
 - An API key for the pfSense REST API.  
   Generate an API key by following:  [Authentication and Authorization](https://pfrest.org/AUTHENTICATION_AND_AUTHORIZATION/)
+
+## Upgrading from v0.1.x ⬆️
+
+**v0.2.0 verifies the pfSense TLS certificate by default.** v0.1.2 and earlier disabled verification on every request, with no way to turn it on. Most pfSense installations use a self-signed certificate, so if yours does, every API call will fail after upgrading until you do one of two things.
+
+Note that this reaches you automatically if you pull the `latest` tag.
+
+The failure is not silent — the service logs the cause and then names both settings:
+
+```
+ERROR - API call failed during 'get_all_host_overrides': ... certificate verify failed: self-signed certificate
+ERROR - TLS certificate verification failed. Mount a CA bundle and set PFSENSE_CA_BUNDLE
+        to its path inside the container, or set PFSENSE_VERIFY_SSL=false to skip
+        verification entirely, which exposes the API token to anyone able to intercept
+        the connection.
+```
+
+**Recommended** — keep verification on by exporting your pfSense CA certificate, mounting it, and pointing `PFSENSE_CA_BUNDLE` at it:
+
+```yaml
+environment:
+  PFSENSE_CA_BUNDLE: "/etc/ssl/certs/pfsense-ca.pem"
+volumes:
+  - ./pfsense-ca.pem:/etc/ssl/certs/pfsense-ca.pem:ro
+```
+
+**Otherwise** — set `PFSENSE_VERIFY_SSL=false` to restore the old behaviour. Understand the trade first: this service authenticates with a pfSense API token, so anyone able to intercept the connection can present any certificate and collect that token.
+
+There is one other breaking change — alias names are now capped at 253 characters, and an over-long alias left behind by an earlier version will stop your DNS resolver until you delete it in the webGUI. See [CHANGELOG.md](CHANGELOG.md) for that and for everything else in this release.
 
 ## Installation Guide 🚀
 
@@ -202,7 +231,8 @@ services:
 
 - Replace `caddy.lab.internal` with the fully qualified hostname of your reverse proxy. Make sure it exists as a host override in pfSense.
 - Replace `nginx.lab.internal` with the fully qualified hostname of the service you're deploying.
-- An alias longer than 253 characters is rejected with a warning and cannot be resolved by DNS anyway. If one already exists in pfSense from an earlier version of this service, remove it in the webGUI — this service will decline to touch it.
+- An alias longer than 253 characters (RFC 1035's limit) is rejected with a warning. No DNS client could resolve such a name anyway, so nothing is lost by refusing it.
+- **If an over-long alias already exists in pfSense from an earlier version of this service, delete it in the webGUI now.** It is not harmless leftover configuration: it makes `unbound-checkconf` fail, so the DNS resolver stops on its next reload and every name on the firewall stops resolving, not just that one. This service cannot clean it up for you — the same length rule that blocks creating such an alias also blocks removing it.
 - `pfsense.dns.remove_on_stop=true` works with `docker run --rm`. This service records a container's alias configuration when it starts, so a container Docker has already deleted by the time its stop event arrives still has its alias removed. Containers already running before this service starts are only recorded when `ADD_ALIASES_ON_STARTUP` is enabled; without it, a pre-existing `--rm` container that stops may leave its alias behind.
 
 ## Contributing 💻

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,7 +15,9 @@ services:
       PFSENSE_API_TOKEN: "${PFSENSE_API_TOKEN}"
       
       # OPTIONAL environment variables
-      # Set to "false" only if you cannot validate your pfSense certificate
+      # TLS certificate verification is ON by default. Set this to "false" only
+      # if you cannot validate your pfSense certificate -- doing so exposes the
+      # API token to anyone able to intercept the connection.
       # PFSENSE_VERIFY_SSL: "true"
       #
       # Path inside the container to a custom CA bundle for pfSense TLS validation

--- a/pfsense.py
+++ b/pfsense.py
@@ -304,6 +304,20 @@ class PFSense:
         logger.error(f"API call failed during '{context}': {sanitize_for_log(error)}")
         if isinstance(error, requests.HTTPError):
             logger.error(f"HTTP Status Code: {error.response.status_code}")
+        if isinstance(error, requests.exceptions.SSLError):
+            # requests reports the cause accurately but names nothing an operator can
+            # set. Verification defaults to on, which this service did not always do,
+            # so someone upgrading has no reason to know these settings exist.
+            #
+            # Deliberately SSLError and not its ConnectionError parent: advice to
+            # consider switching verification off must not appear every time the host
+            # is simply unreachable. A test pins that boundary.
+            logger.error(
+                "TLS certificate verification failed. Mount a CA bundle and set "
+                "PFSENSE_CA_BUNDLE to its path inside the container, or set "
+                "PFSENSE_VERIFY_SSL=false to skip verification entirely, which "
+                "exposes the API token to anyone able to intercept the connection."
+            )
 
     def get_all_host_overrides(self):
         """Returns all the host overrides defined in pfSense"""

--- a/tests/test_pfsense.py
+++ b/tests/test_pfsense.py
@@ -163,6 +163,65 @@ def test_http_error_logs_status_without_response_body(monkeypatch, caplog):
     assert "sensitive response body" not in caplog.text
 
 
+def test_a_tls_verification_failure_names_the_settings_that_fix_it(monkeypatch, caplog):
+    """
+    A certificate failure must point at the two settings that resolve it.
+
+    Verification defaults to on, which is a change from this service's own earlier
+    behaviour of never verifying. requests reports the cause accurately -- "certificate
+    verify failed: self-signed certificate" -- but names nothing an operator can set,
+    and someone upgrading has no reason to know PFSENSE_VERIFY_SSL exists, because in
+    the version they are upgrading from it did not.
+    """
+    monkeypatch.setattr("pfsense.time.sleep", lambda _seconds: None)
+
+    def fake_get(**_kwargs):
+        raise requests.exceptions.SSLError(
+            "certificate verify failed: self-signed certificate"
+        )
+
+    monkeypatch.setattr("pfsense.requests.get", fake_get)
+
+    client = PFSense("pfsense.lab.internal", "secret-token")
+
+    with caplog.at_level(logging.ERROR):
+        assert client.get_all_host_overrides() == []
+
+    hints = [m for m in log_messages(caplog) if "PFSENSE_CA_BUNDLE" in m]
+    assert len(hints) == 1
+    assert "PFSENSE_VERIFY_SSL" in hints[0]
+    # The underlying cause must survive alongside the hint; a hint that replaced the
+    # real error would send someone to the wrong setting when the failure is expiry
+    # or a hostname mismatch rather than an untrusted issuer.
+    assert "certificate verify failed" in caplog.text
+    assert "secret-token" not in caplog.text
+
+
+def test_an_ordinary_connection_error_does_not_suggest_disabling_tls(monkeypatch, caplog):
+    """
+    The hint is for certificate failures only, and that boundary is the point.
+
+    requests.exceptions.SSLError subclasses ConnectionError, so a check written in the
+    wrong order would fire this hint for every unplugged cable and unreachable host.
+    Advice to consider turning off certificate validation, printed whenever the network
+    hiccups, is how a fail-secure default gets switched off for an unrelated reason.
+    """
+    monkeypatch.setattr("pfsense.time.sleep", lambda _seconds: None)
+
+    def fake_get(**_kwargs):
+        raise requests.ConnectionError("connection refused")
+
+    monkeypatch.setattr("pfsense.requests.get", fake_get)
+
+    client = PFSense("pfsense.lab.internal", "secret-token")
+
+    with caplog.at_level(logging.ERROR):
+        assert client.get_all_host_overrides() == []
+
+    assert "PFSENSE_CA_BUNDLE" not in caplog.text
+    assert "PFSENSE_VERIFY_SSL" not in caplog.text
+
+
 def test_get_all_host_overrides_returns_empty_list_on_network_errors(monkeypatch):
     def fake_get(**_kwargs):
         raise requests.ConnectionError("connection failed")


### PR DESCRIPTION
Preparation for a `v0.2.0` release. **No tag is pushed by this PR.**

## The problem

`v0.1.2` sent every pfSense request with certificate verification disabled, hardcoded, with no way to turn it on. This service verifies by default now. Most pfSense installations use a self-signed certificate, so for a typical existing user **every API call fails after upgrading** — and because the publish job also moves `:latest`, they get that on their next pull without asking for it.

## Why the default is not being reverted

Reverting would avoid the break, but at a cost that outlasts it:

- The credential at stake is a **pfSense API token** — full firewall control. With verification off, anyone able to intercept the connection can present any certificate and collect it on the first request.
- Reverting doesn't only preserve behaviour for existing users. It re-imposes an insecure default on every **new** user, who has no `v0.1.2` to be compatible with, and does so silently.
- `0.x` semantic versioning exists for exactly this. A version bump with release notes is the cheapest moment this break will ever be available.

What was actually missing was not a weaker default but **a message someone can act on**. `requests` reports the cause accurately — `certificate verify failed: self-signed certificate` — but names nothing an operator can set, and someone upgrading has no reason to know `PFSENSE_VERIFY_SSL` exists, because in the version they are leaving it did not.

## The code change

`_handle_api_error` logs one extra line for a `requests.exceptions.SSLError`, naming `PFSENSE_CA_BUNDLE` and `PFSENSE_VERIFY_SSL`. Confirmed against the test VM's real self-signed certificate, not only in tests:

```
ERROR - API call failed during 'get_all_host_overrides': ... certificate verify failed: self-signed certificate
ERROR - TLS certificate verification failed. Mount a CA bundle and set PFSENSE_CA_BUNDLE to its
        path inside the container, or set PFSENSE_VERIFY_SSL=false to skip verification entirely,
        which exposes the API token to anyone able to intercept the connection.
```

Two properties are deliberate, and both are pinned:

- **The hint is added to the underlying error, never a replacement.** The cause matters when the failure is certificate expiry or a hostname mismatch rather than an untrusted issuer, and a hint that swallowed it would send someone to the wrong setting.
- **It keys on `SSLError`, not its `ConnectionError` parent.** `SSLError` subclasses `ConnectionError`, so a check written one level too broad would print "consider turning off certificate validation" every time the firewall is briefly unreachable. That is how a fail-secure default gets switched off for an unrelated reason. `test_an_ordinary_connection_error_does_not_suggest_disabling_tls` fails if the check is widened.

## Documentation

Audited across the repo rather than only where the change landed.

- **`CHANGELOG.md` is new.** The repo had none, and nothing since `v0.1.2` (January 2025) was recorded anywhere a user would look. It leads with the two breaking changes, then covers what was added and fixed across the thirty commits since.
- **`README.md` gains an "Upgrading from v0.1.x" section** with both remedies and the note that `:latest` carries the change.
- **`README.md` overstated self-signed support.** The feature list said the service "works with self-signed certificates" flatly. True, but only via a CA bundle or by turning verification off.
- **`README.md` understated the over-long alias hazard.** It said such a name "cannot be resolved by DNS anyway", which reads as harmless. Per PR #19 it stops the resolver on its next reload and takes every other name on the firewall down with it. Now says to delete it and not wait.
- **`docker-compose.yaml`** states that verification is on by default, rather than only explaining how to switch it off.
- **`AGENTS.md`** records the hint and why it must not move to `ConnectionError`.

`CONTRIBUTING.md` and `test-env/README.md` were checked and needed nothing.

## Test ownership

The two tests were written before the implementation, and the hint test was confirmed failing first. Nothing pre-existing under `tests/` was modified or weakened.

## Checks

`py_compile`, pylint 10.00/10, `pip-audit --strict` on both requirements files, 144 tests with the coverage gate at 99.50%, `docker build`, and the full live VM smoke test all pass.

## Not included

The option to publish a tag **without** moving `:latest` is not in this PR — it targets the same concern from a different angle and is worth deciding separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)