### PR TITLE
Stop the API token reaching the log through an exception message

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ uv pip install -r requirements.txt -r requirements-dev.txt
 
 ```bash
 .venv/bin/python -m py_compile main.py pfsense.py   # required after changing either Python file
-.venv/bin/python -m pytest                          # full suite (142 tests)
+.venv/bin/python -m pytest                          # full suite (150 tests)
 .venv/bin/python -m pytest --cov --cov-report=term-missing   # with the coverage gate
 .venv/bin/python -m pytest tests/test_main.py::test_parse_alias_labels_returns_alias_config   # single test
 .venv/bin/python -m pylint main.py pfsense.py       # must stay at 10.00/10
@@ -217,6 +217,12 @@ This no-op has a cost, and it is actionable rather than merely a lament: because
 `test_handle_error_escapes_the_message_but_keeps_the_traceback` asserts through `record.getMessage()`, which structurally excludes `exc_info`. The property that makes that test correct also means a green suite is not evidence the traceback is clean. This finding is defended by review, not by test.
 
 Never log API tokens, secrets, full authorization headers, sensitive environment values, or API response bodies. `_handle_api_error` logs the exception and status code but not `response.text`, and `test_http_error_logs_status_without_response_body` enforces it.
+
+**An exception message can carry the token, so one exception type is never logged.** `requests` validates header values and raises `requests.exceptions.InvalidHeader` with **the offending value embedded in the message**. The only header this service sets is `X-API-Key`, so logging that message printed the API token in cleartext — on every call, since the request fails identically each time, flooding the log and anything downstream of it with a credential that can rewrite firewall DNS. `sanitize_for_log` does not help: it escapes the newline and renders the token characters as they are. `_handle_api_error` therefore returns early for `InvalidHeader` with a fixed message that names `PFSENSE_API_TOKEN` and prints no value. Do not "improve" that branch by including the exception text.
+
+There are two layers, and the outer one is why the inner is rarely reached. `main.py` **trims surrounding whitespace from `PFSENSE_API_TOKEN`** at startup, because a trailing newline is what `$(cat /run/secrets/token)` and a file-based Kubernetes secret both produce, and no API token has meaningful surrounding whitespace — trimming turns the common misconfiguration into a working deployment rather than a loud failure with a secret attached. What survives trimming and is still non-printable (an embedded line break in a pasted token) exits 1 at startup, naming the variable and never the value. The documented deployment paths happened to mask this — `docker run --env-file` strips a trailing `\r` and `docker compose` strips a leading space from a `.env` value — which is exactly why it went unnoticed.
+
+`_handle_api_error`'s status-code branch requires `error.response is not None`. That is load-bearing, not defensive noise: the function runs inside an `except` block, so an `AttributeError` there escapes `_request`'s handler, escapes `_mutate_alias`'s, and reaches `run()`'s broad handler, which exits the process — inverting the contract that an API failure logs and returns `False` rather than killing the service.
 
 `_handle_api_error` also logs one extra line for a `requests.exceptions.SSLError`, naming `PFSENSE_CA_BUNDLE` and `PFSENSE_VERIFY_SSL`. This exists because verification defaults to on while this service's own `v0.1.x` never verified at all, so an upgrading operator meets a certificate error naming a setting they have no reason to know exists. Two properties are deliberate. The hint is **added to** the underlying error, never a replacement for it — the cause matters when the failure is expiry or a hostname mismatch rather than an untrusted issuer. And it keys on `SSLError` specifically, **not** its `ConnectionError` parent: advice to consider switching verification off must not print every time the firewall is briefly unreachable, which is how a fail-secure default gets disabled for an unrelated reason. `test_an_ordinary_connection_error_does_not_suggest_disabling_tls` pins that boundary; widening the check to `ConnectionError` fails it.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,13 @@ also blocks removing it.
   log line. Values are also length-capped.
 - **A pfSense API error no longer logs the response body**, which could contain data
   not intended for the log.
+- **The API token can no longer be written to the log.** If `PFSENSE_API_TOKEN` had a
+  trailing newline or a leading space — what `$(cat /run/secrets/token)` and file-based
+  Kubernetes secrets produce — `requests` rejected the header and raised an error with
+  the token embedded in its message, which was then logged in cleartext on every single
+  API call. Surrounding whitespace is now trimmed at startup, so those tokens simply
+  work; anything still malformed exits at startup naming the variable but never the
+  value; and that class of error is never logged with its message.
 - **The service survives a SIGTERM with work in flight**, flushing staged changes
   before exit.
 

--- a/main.py
+++ b/main.py
@@ -59,7 +59,26 @@ def get_positive_float_env(var_name, default):
     return value
 
 PFSENSE_HOSTNAME = get_env_var("PFSENSE_HOSTNAME")
-PFSENSE_API_TOKEN = get_env_var("PFSENSE_API_TOKEN")
+# Trim surrounding whitespace from the token. A trailing newline is what
+# `$(cat /run/secrets/token)` and a file-based Kubernetes secret both produce, and a
+# leading space is an easy compose typo. requests rejects a header value with either,
+# raising InvalidHeader with the value embedded in its message -- which is how the token
+# used to end up in the log. No API token has meaningful surrounding whitespace, so
+# trimming makes the common misconfiguration simply work instead of failing loudly with
+# a secret attached. A token malformed some other way is caught below.
+PFSENSE_API_TOKEN = get_env_var("PFSENSE_API_TOKEN").strip()
+if not PFSENSE_API_TOKEN:
+    logger.critical("PFSENSE_API_TOKEN is set but contains only whitespace.")
+    sys.exit(1)
+if any(not character.isprintable() for character in PFSENSE_API_TOKEN):
+    # Never name the value here, only the variable -- reporting a malformed secret must
+    # not print it. Trimming above has already removed surrounding whitespace, so what
+    # is left is embedded, e.g. a line break in the middle of a pasted token.
+    logger.critical(
+        "PFSENSE_API_TOKEN contains non-printable characters, such as an embedded "
+        "line break. Check how the value is being set. It is not logged."
+    )
+    sys.exit(1)
 PFSENSE_VERIFY_SSL = os.getenv("PFSENSE_VERIFY_SSL", "true").lower() != "false"
 PFSENSE_CA_BUNDLE = os.getenv("PFSENSE_CA_BUNDLE")
 if PFSENSE_CA_BUNDLE and not os.access(PFSENSE_CA_BUNDLE, os.R_OK):

--- a/pfsense.py
+++ b/pfsense.py
@@ -301,8 +301,30 @@ class PFSense:
         :param error: The exception raised during the API call.
         :param context: Additional context about the API call.
         """
+        if isinstance(error, requests.exceptions.InvalidHeader):
+            # Do NOT log this exception's message. requests embeds the offending header
+            # value in it, and the only header this service sets is the API token, so
+            # logging the message prints the token in cleartext -- on every call, since
+            # the request fails identically each time. sanitize_for_log does not save
+            # us here: it escapes the newline and renders the token characters as-is.
+            #
+            # main.py trims surrounding whitespace from the token so the common causes
+            # (a file-based secret, `$(cat ...)`) never reach this branch at all. This
+            # is the second layer, for a token malformed some other way and for any
+            # caller constructing PFSense directly.
+            logger.error(
+                f"API call failed during '{context}': the request headers were "
+                "rejected as malformed. Check PFSENSE_API_TOKEN for stray whitespace "
+                "or line breaks. The value is not logged."
+            )
+            return
+
         logger.error(f"API call failed during '{context}': {sanitize_for_log(error)}")
-        if isinstance(error, requests.HTTPError):
+        if isinstance(error, requests.HTTPError) and error.response is not None:
+            # `error.response is not None` is required, not defensive noise: this runs
+            # inside an `except` block, so an AttributeError here would escape every
+            # handler up to run() and exit the process -- inverting the contract that an
+            # API failure logs and returns False rather than killing the service.
             logger.error(f"HTTP Status Code: {error.response.status_code}")
         if isinstance(error, requests.exceptions.SSLError):
             # requests reports the cause accurately but names nothing an operator can

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -457,6 +457,70 @@ def test_a_readable_ca_bundle_starts_normally(monkeypatch, tmp_path):
     assert main.PFSENSE_VERIFY_SSL is False
 
 
+def _load_main_with_token(monkeypatch, token):
+    """Import main with a specific PFSENSE_API_TOKEN, returning the module."""
+    fake_client = FakeDockerClient()
+    fake_docker = types.SimpleNamespace(
+        from_env=lambda: fake_client,
+        errors=types.SimpleNamespace(DockerException=DockerException, NotFound=DockerNotFound),
+    )
+    monkeypatch.setenv("PFSENSE_HOSTNAME", "pfsense.lab.internal")
+    monkeypatch.setenv("PFSENSE_API_TOKEN", token)
+    monkeypatch.delenv("ADD_ALIASES_ON_STARTUP", raising=False)
+    monkeypatch.delenv("PFSENSE_VERIFY_SSL", raising=False)
+    monkeypatch.delenv("PFSENSE_CA_BUNDLE", raising=False)
+    monkeypatch.setitem(sys.modules, "docker", fake_docker)
+    sys.modules.pop("main", None)
+    return importlib.import_module("main")
+
+
+def test_surrounding_whitespace_is_trimmed_from_the_token(monkeypatch):
+    """
+    A trailing newline must not break the service, because it is the common case.
+
+    `$(cat /run/secrets/token)` and a file-based Kubernetes secret both produce one.
+    requests rejects such a header value and embeds it in the exception message, which
+    is how the token used to reach the log. No API token has meaningful surrounding
+    whitespace, so trimming is the fix that keeps a working deployment working.
+    """
+    main = _load_main_with_token(monkeypatch, "  tok-abc123\n")
+
+    assert main.PFSENSE_API_TOKEN == "tok-abc123"
+
+
+def test_a_whitespace_only_token_exits_at_startup(monkeypatch, caplog):
+    with caplog.at_level(logging.CRITICAL):
+        try:
+            _load_main_with_token(monkeypatch, "   \n")
+        except SystemExit as exc:
+            assert exc.code == 1
+        else:
+            raise AssertionError("import did not exit")
+
+    assert "only whitespace" in caplog.text
+
+
+def test_a_token_with_an_embedded_line_break_exits_without_logging_it(monkeypatch, caplog):
+    """
+    Rejecting a malformed secret must not print the secret while doing so.
+
+    Trimming handles surrounding whitespace, so what reaches here is embedded -- a line
+    break in the middle of a pasted token. The message names the variable, never the
+    value, which is the whole point of failing here rather than at the request.
+    """
+    with caplog.at_level(logging.CRITICAL):
+        try:
+            _load_main_with_token(monkeypatch, "SUPERSECRET\nTOKEN")
+        except SystemExit as exc:
+            assert exc.code == 1
+        else:
+            raise AssertionError("import did not exit")
+
+    assert "PFSENSE_API_TOKEN" in caplog.text
+    assert "SUPERSECRET" not in caplog.text
+    assert "non-printable" in caplog.text
+
+
 def test_cleanup_closes_client_and_exits_zero(monkeypatch):
     main, fake_client = load_main(monkeypatch)
 

--- a/tests/test_pfsense.py
+++ b/tests/test_pfsense.py
@@ -222,6 +222,79 @@ def test_an_ordinary_connection_error_does_not_suggest_disabling_tls(monkeypatch
     assert "PFSENSE_VERIFY_SSL" not in caplog.text
 
 
+def test_a_token_with_a_trailing_newline_never_reaches_the_log(monkeypatch, caplog):
+    """
+    requests embeds the offending header VALUE in InvalidHeader's message.
+
+    That message is a RequestException, so it lands in _handle_api_error and would be
+    logged verbatim -- printing the firewall API token at ERROR on every call, forever,
+    because the same request fails identically every time. sanitize_for_log does not
+    help: it escapes the newline and renders the token characters as they are.
+
+    A trailing newline is the realistic case, not a contrived one. It is what
+    `$(cat /run/secrets/token)` and a file-based Kubernetes secret both produce.
+    """
+    monkeypatch.setattr("pfsense.time.sleep", lambda _seconds: None)
+
+    def fake_get(**_kwargs):
+        raise requests.exceptions.InvalidHeader(
+            "Invalid leading whitespace, reserved character(s), or return character(s) "
+            "in header value: 'SUPERSECRETTOKEN\\n'"
+        )
+
+    monkeypatch.setattr("pfsense.requests.get", fake_get)
+
+    client = PFSense("pfsense.lab.internal", "SUPERSECRETTOKEN\n")
+
+    with caplog.at_level(logging.ERROR):
+        assert client.get_all_host_overrides() == []
+
+    assert "SUPERSECRETTOKEN" not in caplog.text
+
+
+def test_an_invalid_header_error_still_says_what_went_wrong(monkeypatch, caplog):
+    """
+    Redacting the value must not leave the operator with an unactionable log.
+
+    The whole failure is a malformed token, so the message has to name the variable
+    to check. It must do that without quoting the value it is refusing to print.
+    """
+    monkeypatch.setattr("pfsense.time.sleep", lambda _seconds: None)
+
+    def fake_get(**_kwargs):
+        raise requests.exceptions.InvalidHeader("... in header value: 'SUPERSECRETTOKEN\\n'")
+
+    monkeypatch.setattr("pfsense.requests.get", fake_get)
+
+    client = PFSense("pfsense.lab.internal", "SUPERSECRETTOKEN\n")
+
+    with caplog.at_level(logging.ERROR):
+        assert client.get_all_host_overrides() == []
+
+    assert "PFSENSE_API_TOKEN" in caplog.text
+    assert "SUPERSECRETTOKEN" not in caplog.text
+
+
+def test_handle_api_error_survives_an_http_error_with_no_response(caplog):
+    """
+    An HTTPError carrying no response must not raise out of the error handler.
+
+    _handle_api_error runs inside an `except` block, so an AttributeError here escapes
+    _request's handler, escapes _mutate_alias's, and reaches run()'s broad handler,
+    which exits the process. That inverts the contract that a pfSense API failure logs
+    and returns False rather than killing the service.
+    """
+    client = PFSense("pfsense.lab.internal", "secret-token")
+
+    with caplog.at_level(logging.ERROR):
+        client._handle_api_error(  # pylint: disable=protected-access
+            requests.HTTPError("no response attached"), "ctx"
+        )
+
+    assert "no response attached" in caplog.text
+    assert "HTTP Status Code" not in caplog.text
+
+
 def test_get_all_host_overrides_returns_empty_list_on_network_errors(monkeypatch):
     def fake_get(**_kwargs):
         raise requests.ConnectionError("connection failed")


### PR DESCRIPTION
Found by the security review. **This should land before `v0.2.0` is tagged.**

## The bug

`requests` validates header values and raises `InvalidHeader` with **the offending value embedded in the message**. That is a `RequestException`, so `_request` caught it and `_handle_api_error` logged the whole message — printing the pfSense API token in cleartext, at `ERROR`, on every call, because the request fails identically every time.

`sanitize_for_log` does not help: it escapes the newline and renders the token characters as they are.

Reproduced before the fix:

```
ERROR - API call failed during 'get_all_host_overrides': Invalid leading whitespace,
reserved character(s), or return character(s) in header value: 'SUPERSECRETTOKEN\n'
```

## Why it matters

The trigger is mundane, not contrived. `$(cat /run/secrets/token)` and a file-based Kubernetes secret both leave a trailing newline; a leading space is an easy compose typo. Every API call then fails and re-logs the token — startup scan, every container event, every apply — so one misconfiguration floods the container log, and anything downstream of it, with a credential that can rewrite firewall DNS.

The documented deployment paths happen to mask it: `docker run --env-file` strips a trailing `\r`, and `docker compose` strips a leading space from a `.env` value. That is why it went unnoticed, not why it is harmless — it means the failure only appears for someone deploying differently.

It is pre-existing, not a regression from this week's work, and it contradicts `AGENTS.md`'s "Never log API tokens."

## The fix, in two layers

**Outer** — `main.py` trims surrounding whitespace from `PFSENSE_API_TOKEN`. No API token has meaningful leading or trailing whitespace, so trimming turns the common misconfiguration into a *working deployment* rather than a loud failure with a secret attached. A whitespace-only token, or one still non-printable after trimming (an embedded line break in a pasted value), exits 1 at startup — naming the variable, never the value.

**Inner** — `_handle_api_error` returns early for `InvalidHeader` with a fixed message that names `PFSENSE_API_TOKEN` and prints nothing else. This covers a token malformed some other way, and any caller constructing `PFSense` directly.

After the fix, the same reproduction gives:

```
ERROR - API call failed during 'get_all_host_overrides': the request headers were rejected
as malformed. Check PFSENSE_API_TOKEN for stray whitespace or line breaks. The value is not logged.
```

## Second finding, same function

The status-code branch now requires `error.response is not None`. An `HTTPError` with no response raised `AttributeError` **from inside an `except` block**, so it escaped `_request`'s handler, escaped `_mutate_alias`'s, and reached `run()`'s broad handler — which exits the process. That inverts the contract that an API failure logs and returns `False` rather than killing the service.

I confirmed it raises. Reachability is inferred rather than demonstrated: `raise_for_status()` always attaches a response, and I could not construct a real path. The guard is one condition, so it is worth having regardless.

## Tests

Six, written before the implementation and confirmed failing first — three in `test_pfsense.py` (token absent from the log, the message still actionable, no crash on a response-less `HTTPError`) and three in `test_main.py` (trimming works, whitespace-only exits, embedded break exits without printing the value).

## Verification

150 tests, pylint 10.00/10, coverage 99.51%, `docker build`, and the **full live VM run green** — alias created and resolving, description round-tripping, removed on stop, `--rm` path clean, service alive.

## Also

`AGENTS.md`'s test count corrected from 142 to 150. Both reviewers flagged that drift; it was mine, from PR #21.

## Still to come from the review

The startup-scan strand, the `PENDING_CHANGES` inflation plus two unpinned invariants, and the `test-env` hardening — separate PRs, none of them release-blocking the way this one is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)