### PR TITLE
Retry a failed startup apply instead of stranding it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,6 +163,8 @@ With `apply=False`, a `True` return means **staged in the pfSense configuration 
 
 For the same reason, **a failed flush keeps its changes pending**. `flush_pending_changes()` calls `_defer_retry()` rather than `_record_applied()` when the apply fails, so a later tick or the shutdown flush retries. `_defer_retry()` pushes the timers out a full quiet window so a pfSense outage is not retried on every two-second window tick.
 
+**The startup scan obeys the same rule, and for a while it did not.** When its single `apply_changes()` fails, `add_aliases_on_startup` calls `_record_staged(staged)` to hand the work to the coalescer. It used to only log. That left `PENDING_CHANGES` at `0` while `unapplied_changes` was `True`, and since `flush_pending_changes()` returns at its guard when nothing is pending, neither a window tick nor the shutdown flush ever retried — the aliases sat in `config.xml` with unbound never reloaded, and on an idle host no name resolved until something unrelated happened to trigger an apply. `test_a_failed_startup_apply_stays_pending_and_is_retried` pins both halves: that the count is recorded, and that a later flush actually clears it. Note this is the *whole* reason `_record_staged` takes a count — every other caller passes one.
+
 ### API responses are untrusted input
 
 `get_all_host_overrides()` validates the payload shape — it returns `[]` for a non-list `data` and drops non-dict entries — and every accessor uses `.get()` rather than indexing. A well-formed 200 with an unexpected body previously raised `KeyError`/`TypeError` straight out of this module, which `main()` does not catch, exiting the service instead of logging and carrying on. An API schema change must degrade to a warning, never a crash loop.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,7 +88,9 @@ also blocks removing it.
 - **A failed apply no longer strands changes.** A change that reached the pfSense
   configuration while its apply failed used to be forgotten, so nothing retried it and
   the alias never went live. Pending changes are now retried on a later event or at
-  shutdown.
+  shutdown. This applies to the startup scan too: with `ADD_ALIASES_ON_STARTUP=true`,
+  a failed startup apply used to leave every alias staged in the configuration with the
+  resolver never reloaded, and nothing would retry on an idle host.
 - **Applies are confirmed rather than assumed.** pfSense reloads asynchronously, so
   the request returns before the reload finishes. The service now polls until pfSense
   reports the change applied, and reports a failure if it never does.

--- a/main.py
+++ b/main.py
@@ -159,6 +159,13 @@ def add_aliases_on_startup():
 
     logger.info(f"Applying {staged} staged alias(es) in a single reload...")
     if not NAMESERVER.apply_changes():
+        # Hand the staged changes to the coalescer so a later window tick or the
+        # shutdown flush retries the apply. Logging alone left PENDING_CHANGES at 0, and
+        # flush_pending_changes() returns at its guard when nothing is pending -- so on
+        # an idle host nothing ever retried, and the aliases sat in the configuration
+        # with unbound never reloaded. This is the same rule the event path follows:
+        # what pfSense actually holds decides, not the return value.
+        _record_staged(staged)
         logger.error(
             f"{staged} alias(es) are staged in the pfSense configuration but were not "
             "applied. They will take effect on the next successful apply."
@@ -313,10 +320,10 @@ def should_apply_immediately():
         return False
     return LAST_APPLY_AT is None or time.monotonic() - LAST_APPLY_AT >= APPLY_QUIET_SECONDS
 
-def _record_staged():
-    """Note that a change is staged in pfSense but not yet applied."""
+def _record_staged(count=1):
+    """Note that `count` changes are staged in pfSense but not yet applied."""
     global PENDING_CHANGES, PENDING_SINCE, LAST_CHANGE_AT  # pylint: disable=global-statement
-    PENDING_CHANGES += 1
+    PENDING_CHANGES += count
     LAST_CHANGE_AT = time.monotonic()
     if PENDING_SINCE is None:
         PENDING_SINCE = LAST_CHANGE_AT

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -758,6 +758,45 @@ def test_startup_scan_reports_staged_aliases_when_the_apply_fails(monkeypatch, c
     assert "next successful apply" in caplog.text
 
 
+def test_a_failed_startup_apply_stays_pending_and_is_retried(monkeypatch):
+    """
+    A failed startup apply must leave the coalescer holding the work.
+
+    The event path already does this -- a mutation can land while its apply fails, and
+    unapplied_changes rather than the return value is what says so. The startup scan
+    only logged. PENDING_CHANGES stayed 0, and flush_pending_changes() returns
+    immediately when nothing is pending, so neither a window tick nor the shutdown
+    flush ever retried: the aliases sat in config.xml with unbound never reloaded, and
+    on an idle host no name resolved until something unrelated happened to trigger an
+    apply.
+    """
+    main, fake_client = load_main(monkeypatch)
+    staged = []
+    applies = []
+    fake_client.containers.list = lambda: [
+        _labeled_container("svc0", "svc0.lab.internal"),
+        _labeled_container("svc1", "svc1.lab.internal"),
+    ]
+    nameserver = _recording_nameserver(staged, applies, apply_result=False)
+    main.NAMESERVER = nameserver
+
+    main.add_aliases_on_startup()
+
+    assert len(staged) == 2
+    assert applies == ["apply"]
+    # The failure is tracked, not just logged.
+    assert main.PENDING_CHANGES == 2
+    assert main.PENDING_SINCE is not None
+
+    # A later flush must actually retry it. Without the fix there is nothing to retry,
+    # because PENDING_CHANGES is 0 and flush_pending_changes() returns at its guard.
+    nameserver.apply_result = True
+    main.flush_pending_changes(force=True)
+
+    assert applies == ["apply", "apply"]
+    assert main.PENDING_CHANGES == 0
+
+
 # --- Coalescing: a burst costs one reload, a lone start stays fast -------------
 
 


### PR DESCRIPTION
Found by the correctness review. Stacks conceptually on #25 but touches different code, so either can merge first.

## The bug

`add_aliases_on_startup` stages every alias with `apply=False`, calls `apply_changes()` once, and on failure **only logged**. It never told the coalescer anything, so `PENDING_CHANGES` stayed `0` while `NAMESERVER.unapplied_changes` was `True`.

`flush_pending_changes()` returns at its guard when `PENDING_CHANGES` is falsy — so neither a window tick nor the SIGTERM shutdown flush ever retried.

## Failure scenario

`ADD_ALIASES_ON_STARTUP=true`, twenty labelled containers running, the service restarts, and the apply exhausts its 15-second poll budget on a busy firewall. Twenty alias POSTs land in `config.xml`. unbound is never reloaded. **None of the names resolve**, and on an idle host nothing retries — not a tick, not shutdown — until some unrelated container start happens to take the immediate-apply path.

## Why this one stings

This is precisely the defect `AGENTS.md` says was already fixed:

> trusting the boolean stranded those changes, because nothing was pending so nothing ever retried and the alias never went live

The event path was fixed in PR #11. **The startup path was missed.** `CHANGELOG.md` also stated it as user-facing behaviour — "Pending changes are now retried on a later event or at shutdown" — which was false for this path. Both are corrected here.

## The fix

One call, `_record_staged(staged)`, in the failure branch — so the same rule holds everywhere: what pfSense actually holds decides, not the return value. `_record_staged` gains a count parameter for this; every other caller passes one.

## The test

Written first and confirmed failing:

```
>       assert main.PENDING_CHANGES == 2
E       AssertionError: assert 0 == 2
```

It pins **both** halves — that the count is recorded, and that a later flush actually retries and clears it. The second half is what would have caught this originally: the existing `test_startup_scan_reports_staged_aliases_when_the_apply_fails` asserted only the log line, never the state, which is how a log-and-forget passed for a retry.

## Verification

145 tests, pylint 10.00/10, coverage gate green, `docker build`. No live VM run: this changes only in-process coalescing bookkeeping, and #25 — which does touch the request path — carries a green VM run on the same underlying code.

## Still to come

The `PENDING_CHANGES` inflation on no-op mutations, the two `KNOWN_ALIASES` invariants documented but not pinned, and the `test-env` hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)