### PR TITLE
Checksum the pfRest package and stop the test relay when smoke.sh exits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ uv pip install -r requirements.txt -r requirements-dev.txt
 
 ```bash
 .venv/bin/python -m py_compile main.py pfsense.py   # required after changing either Python file
-.venv/bin/python -m pytest                          # full suite (150 tests)
+.venv/bin/python -m pytest                          # full suite (155 tests)
 .venv/bin/python -m pytest --cov --cov-report=term-missing   # with the coverage gate
 .venv/bin/python -m pytest tests/test_main.py::test_parse_alias_labels_returns_alias_config   # single test
 .venv/bin/python -m pylint main.py pfsense.py       # must stay at 10.00/10
@@ -139,13 +139,15 @@ Coalescing state (`PENDING_CHANGES`, `PENDING_SINCE`, `LAST_CHANGE_AT`, `LAST_AP
 
 So `remember_alias_config()` records `(container_name, alias_config)` in `KNOWN_ALIASES`, keyed by container ID, whenever a start event is handled — and in `add_aliases_on_startup`, which is the only chance to record a container that was already running when this service started. On `NotFound`, `recall_alias_config()` supplies the fallback and the removal proceeds. When nothing was recorded, the original warning still fires.
 
-Three properties are deliberate:
+Three properties are deliberate, and all three are now pinned by tests — two of them were not, and survived deliberate mutation of the source until `test_both_die_and_stop_remove_the_alias_for_a_deleted_container` and `test_re_recording_a_container_makes_it_the_newest_entry` were added:
 
 - **Only a stop is answered from the record.** `recall_alias_config` returns `None` for any action other than `stop`/`die`. A start event for a container that has already gone is genuinely nothing to act on, and treating it as a removal would delete an alias in response to the wrong event.
 - **The `remove_on_stop` opt-in still applies.** The recorded configuration is checked the same way a live label read would be, so falling back never removes an alias the labels did not ask to remove.
 - **Entries are not dropped on stop.** Docker emits both `die` and `stop` for one shutdown, and the second event must reach the same answer as the first. Removing the entry on the first would make the second log "Container not found" for a container that was handled correctly a moment earlier.
 
-That last choice means container IDs — which are never reused — would accumulate for the life of the process, so `KNOWN_ALIASES_MAX` (512) bounds the table and the oldest entry is evicted on overflow. Eviction relies on dictionaries preserving insertion order; `remember_alias_config` deletes before reinserting so a re-recorded container counts as newest. The second removal attempt costs one API call and no extra apply: `del_host_override_alias` returns `False` without mutating when the alias is already absent, so `unapplied_changes` stays clear and `_record_change_outcome` does nothing.
+That last choice means container IDs — which are never reused — would accumulate for the life of the process, so `KNOWN_ALIASES_MAX` (512) bounds the table and the oldest entry is evicted on overflow. Eviction relies on dictionaries preserving insertion order; `remember_alias_config` deletes before reinserting so a re-recorded container counts as newest. The second removal attempt costs one API call and no extra apply: `del_host_override_alias` returns `False` without mutating when the alias is already absent, so `_record_change_outcome` does nothing.
+
+**How that no-op is detected is the subtle part, and reading `unapplied_changes` was not enough.** That flag answers "is there unapplied work?" and saturates at `True` for the length of a burst, so it cannot answer "did *this* call change anything?" — which is the question `_record_change_outcome` actually needs. Reading it alone meant the second of Docker's `die`/`stop` pair counted as a staged change once anything else was pending: a `docker compose down` of twenty services reported roughly 38 coalesced changes for 19 real removals, and a container in a restart loop could hold the quiet window open until the `APPLY_MAX_WAIT_SECONDS` cap. `PFSense.change_count` is therefore a **monotonic count of mutations that landed**, and `process_start_event` / `process_stop_event` compare it across the call and pass the result to `_record_change_outcome` as `mutated`. Both fields are needed and they answer different questions — do not collapse them. A fake nameserver in a test must move `change_count` on a successful mutation, or it models a service that never changes anything.
 
 This is bounded, not unlimited memory: a container that starts, is recorded, and stops more than 512 container-starts later has been evicted, and its `--rm` removal fails the old way. Raising the cap trades memory for that window.
 

--- a/main.py
+++ b/main.py
@@ -398,7 +398,7 @@ def flush_pending_changes(force=False):
         "Retrying after the quiet period."
     )
 
-def _record_change_outcome(succeeded):
+def _record_change_outcome(succeeded, mutated):
     """
     Update coalescing state from what pfSense actually holds, not from the return value
     alone.
@@ -406,7 +406,15 @@ def _record_change_outcome(succeeded):
     A mutation can land in the configuration while its apply fails, which returns False
     even though something is now staged. Trusting the boolean stranded those changes:
     nothing was pending, so nothing ever retried the apply and the alias never went live.
+
+    `mutated` says whether THIS call changed anything, which unapplied_changes cannot:
+    that flag is a single boolean and stays True for the whole burst, so a later no-op --
+    the second of Docker's die/stop pair, finding the alias already gone -- read as a
+    staged change. It inflated the count and restarted the quiet window.
     """
+    if not mutated:
+        return
+
     if NAMESERVER.unapplied_changes:
         _record_staged()
     elif succeeded:
@@ -415,18 +423,20 @@ def _record_change_outcome(succeeded):
 def process_start_event(host_override_fqdn, alias_fqdn, alias_descr):
     """Process a container start event and add an alias if necessary."""
     immediate = should_apply_immediately()
-    _record_change_outcome(
-        NAMESERVER.add_host_override_alias(
-            host_override_fqdn, alias_fqdn, alias_descr, apply=immediate
-        )
+    before = NAMESERVER.change_count
+    succeeded = NAMESERVER.add_host_override_alias(
+        host_override_fqdn, alias_fqdn, alias_descr, apply=immediate
     )
+    _record_change_outcome(succeeded, NAMESERVER.change_count > before)
 
 def process_stop_event(host_override_fqdn, alias_fqdn):
     """Process a container stop event and remove an alias if necessary."""
     immediate = should_apply_immediately()
-    _record_change_outcome(
-        NAMESERVER.del_host_override_alias(host_override_fqdn, alias_fqdn, apply=immediate)
+    before = NAMESERVER.change_count
+    succeeded = NAMESERVER.del_host_override_alias(
+        host_override_fqdn, alias_fqdn, apply=immediate
     )
+    _record_change_outcome(succeeded, NAMESERVER.change_count > before)
 
 NAMESERVER = None
 

--- a/pfsense.py
+++ b/pfsense.py
@@ -163,6 +163,11 @@ class PFSense:
         # been confirmed applied. Callers use it to keep retrying rather than assuming a
         # False return meant nothing happened.
         self.unapplied_changes = False
+        # Monotonic count of mutations that actually landed. unapplied_changes answers
+        # "is there unapplied work?" but saturates at True, so it cannot answer "did
+        # THIS call change anything?" once a burst is under way. Callers compare this
+        # across a call to tell a real mutation from a no-op.
+        self.change_count = 0
         if self.verify_ssl is False:
             urllib3.disable_warnings(InsecureRequestWarning)
         logger.info(f"pfSense host set to {self.pfsense_host}")
@@ -458,6 +463,7 @@ class PFSense:
         # nothing tracking it -- main._record_change_outcome() reads this flag, not
         # the boolean returned here.
         self.unapplied_changes = True
+        self.change_count += 1
 
         if apply_now and not self.apply_changes():
             return False

--- a/test-env/README.md
+++ b/test-env/README.md
@@ -89,6 +89,14 @@ Docker bridge address accepts the TCP connection and then carries no data, so
 the client sees a connect that succeeds followed by a read timeout. `relay.sh`
 socats the bridge address to the working loopback forward instead.
 
+**Stop the relay when you are done with it.** `smoke.sh` now does that in its
+exit trap, but if you start it by hand, run `relay.sh stop` afterwards. The
+bridge address is reachable from *every* container on the default Docker
+network, not just this service, and it forwards to a firewall that keeps
+pfSense's default `admin` / `pfsense` credentials with login protection turned
+off. Left running on a machine that also runs untrusted containers, it is a
+credential-free path to a firewall admin GUI.
+
 ## Things that bite
 
 **The lockout.** Every request from the host reaches pfSense as `10.0.3.2`, the

--- a/test-env/bootstrap.sh
+++ b/test-env/bootstrap.sh
@@ -142,6 +142,8 @@ if [[ ! -f "$PFSENSE_IMAGE" ]]; then
 fi
 
 [[ -f "$RESTAPI_PKG" ]] || "${CURL[@]}" -o "$RESTAPI_PKG" "$RESTAPI_URL"
+echo "$RESTAPI_SHA256  $RESTAPI_PKG" | sha256sum -c - \
+  || die "checksum mismatch on $RESTAPI_PKG — delete it and retry"
 
 log "creating a 20 GB disk"
 qemu-img create -f qcow2 "$DISK" 20G >/dev/null

--- a/test-env/lib/common.sh
+++ b/test-env/lib/common.sh
@@ -26,6 +26,13 @@ PFSENSE_IMAGE_SHA256="bc3ee3d82b8195387114a64c3398505f238a6cb5393ae9b2d45d1bf940
 RESTAPI_VERSION="v2.4.3"
 RESTAPI_PKG="pfSense-${PFSENSE_VERSION}-pkg-RESTAPI.pkg"
 RESTAPI_URL="https://github.com/pfrest/pfSense-pkg-RESTAPI/releases/download/${RESTAPI_VERSION}/${RESTAPI_PKG}"
+# bootstrap.sh installs this package as root inside the VM, so pin it like the
+# pfSense image above. A GitHub release asset is mutable -- the publisher can
+# replace it without moving the tag -- so the version alone is not an immutable
+# reference. Take the hash from the asset's `digest` field, which GitHub computes:
+#   gh api repos/pfrest/pfSense-pkg-RESTAPI/releases/tags/$RESTAPI_VERSION \
+#     --jq '.assets[] | select(.name == "'"$RESTAPI_PKG"'") | .digest'
+RESTAPI_SHA256="69f84530890c62dc0209e188af3f697fa1952b9de532720cfc6e3ebe42331438"
 
 # Guest addressing. The LAN address is fixed because QEMU's port forwarding
 # rules name it explicitly.
@@ -45,7 +52,7 @@ DNS_PORT="15353"
 BRIDGE_IP="172.17.0.1"
 
 export PFSENSE_VERSION PFSENSE_IMAGE PFSENSE_IMAGE_URL PFSENSE_IMAGE_SHA256
-export RESTAPI_VERSION RESTAPI_PKG RESTAPI_URL
+export RESTAPI_VERSION RESTAPI_PKG RESTAPI_URL RESTAPI_SHA256
 export LAN_IP LAN_GATEWAY PARENT_HOST PARENT_DOMAIN PARENT_IP
 export API_PORT SSH_PORT DNS_PORT BRIDGE_IP
 

--- a/test-env/smoke.sh
+++ b/test-env/smoke.sh
@@ -31,10 +31,23 @@ FAILURES=0
 pass() { printf '  \033[32mok\033[0m   %s\n' "$*"; }
 fail() { printf '  \033[31mFAIL\033[0m %s\n' "$*"; FAILURES=$(( FAILURES + 1 )); }
 
+# Containers only. This is also called mid-script to clear leftovers from an
+# earlier run, so it must not touch anything the run still needs -- notably the
+# relay, which is started before it.
 cleanup() {
   docker rm -f "$SERVICE" "$TARGET" "$EPHEMERAL" >/dev/null 2>&1 || true
 }
-trap cleanup EXIT
+
+# Teardown, on exit only. The relay binds the Docker bridge address, which every
+# container on the default network can reach, and forwards to a firewall running
+# default credentials with login protection disabled. Leaving it up after the run
+# turns a test fixture into a standing credential-free path to that admin GUI on
+# any machine that also runs untrusted containers.
+on_exit() {
+  cleanup
+  "$TEST_ENV_DIR/relay.sh" stop >/dev/null 2>&1 || true
+}
+trap on_exit EXIT
 
 resolves()     { [[ -n "$(dig +short +timeout=3 "@127.0.0.1" -p "$DNS_PORT" "$1" 2>/dev/null)" ]]; }
 not_resolves() { ! resolves "$1"; }

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -675,15 +675,24 @@ def test_process_events_delegate_to_nameserver(monkeypatch):
     main, _fake_client = load_main(monkeypatch)
     added = []
     removed = []
-    main.NAMESERVER = types.SimpleNamespace(
-        unapplied_changes=False,
-        add_host_override_alias=lambda host, alias, descr, apply: added.append(
-            (host, alias, descr, apply)
-        )
-        or True,
-        del_host_override_alias=lambda host, alias, apply: removed.append((host, alias, apply))
-        or True,
-    )
+    # change_count increments on a mutation that lands, as the real PFSense does. The
+    # coalescer compares it across the call to tell a real change from a no-op, so a
+    # fake that never moves it would model a service that never changes anything.
+    nameserver = types.SimpleNamespace(unapplied_changes=False, change_count=0)
+
+    def add(host, alias, descr, apply):
+        added.append((host, alias, descr, apply))
+        nameserver.change_count += 1
+        return True
+
+    def remove(host, alias, apply):
+        removed.append((host, alias, apply))
+        nameserver.change_count += 1
+        return True
+
+    nameserver.add_host_override_alias = add
+    nameserver.del_host_override_alias = remove
+    main.NAMESERVER = nameserver
 
     main.process_start_event("caddy.lab.internal", "nginx.lab.internal", "nginx service")
     main.process_stop_event("caddy.lab.internal", "nginx.lab.internal")
@@ -880,6 +889,10 @@ class RecordingNameserver:
         self.apply_result = apply_result
         self.mutation_result = mutation_result
         self.unapplied_changes = False
+        # Monotonic count of mutations that actually landed. unapplied_changes is a
+        # boolean and saturates, so it cannot tell "this call changed something" from
+        # "something was already staged" once a burst is under way.
+        self.change_count = 0
 
     def _mutate(self, alias, apply):
         self.staged.append((alias, apply))
@@ -887,6 +900,7 @@ class RecordingNameserver:
             return False
 
         self.unapplied_changes = True
+        self.change_count += 1
         if not apply:
             return True
 
@@ -1189,6 +1203,8 @@ def test_a_failed_add_stages_nothing(monkeypatch):
     applies = []
     main.NAMESERVER = types.SimpleNamespace(
         unapplied_changes=False,
+        # Never moves, because neither mutator changes anything -- which is the point.
+        change_count=0,
         add_host_override_alias=lambda *_args, **_kwargs: False,
         del_host_override_alias=lambda *_args, **_kwargs: False,
         apply_changes=lambda: applies.append("apply") or True,
@@ -1201,6 +1217,55 @@ def test_a_failed_add_stages_nothing(monkeypatch):
 
     assert main.PENDING_CHANGES == 0
     assert applies == []
+
+
+def test_a_no_op_removal_during_a_burst_does_not_inflate_the_pending_count(monkeypatch):
+    """
+    Docker emits both `die` and `stop` for one shutdown. The second finds the alias
+    already gone, so the mutator returns False without touching pfSense.
+
+    unapplied_changes is a single boolean that saturates: once anything is staged it
+    stays True, so reading it alone counted that no-op as a staged change. A
+    `docker compose down` of twenty services then reported roughly 38 coalesced
+    changes for 19 real removals.
+    """
+    main, _fake_client = load_main(monkeypatch)
+    nameserver = RecordingNameserver()
+    main.NAMESERVER = nameserver
+    monkeypatch.setattr(main, "APPLY_QUIET_SECONDS", 3600.0)
+    monkeypatch.setattr(main, "LAST_APPLY_AT", time.monotonic())
+
+    main.process_stop_event("caddy.lab.internal", "a.lab.internal")
+    assert main.PENDING_CHANGES == 1
+
+    # The second event for the same container: nothing left to remove.
+    nameserver.mutation_result = False
+    main.process_stop_event("caddy.lab.internal", "a.lab.internal")
+
+    assert main.PENDING_CHANGES == 1
+
+
+def test_a_no_op_event_does_not_hold_the_quiet_window_open(monkeypatch):
+    """
+    A no-op must not restart the coalescing clock.
+
+    A container in a restart loop emitting repeated die/stop for an already-removed
+    alias would otherwise keep pushing LAST_CHANGE_AT forward, delaying a genuinely
+    pending change from the 10s quiet window out to the 60s maximum wait.
+    """
+    main, _fake_client = load_main(monkeypatch)
+    nameserver = RecordingNameserver()
+    main.NAMESERVER = nameserver
+    monkeypatch.setattr(main, "APPLY_QUIET_SECONDS", 3600.0)
+    monkeypatch.setattr(main, "LAST_APPLY_AT", time.monotonic())
+
+    main.process_stop_event("caddy.lab.internal", "a.lab.internal")
+    change_at = main.LAST_CHANGE_AT
+
+    nameserver.mutation_result = False
+    main.process_stop_event("caddy.lab.internal", "a.lab.internal")
+
+    assert main.LAST_CHANGE_AT == change_at
 
 
 def test_a_coalesced_removal_is_staged_like_an_addition(monkeypatch):
@@ -1573,6 +1638,69 @@ def test_the_remembered_alias_table_is_bounded(monkeypatch):
     assert len(main.KNOWN_ALIASES) == main.KNOWN_ALIASES_MAX
     assert "id-0" not in main.KNOWN_ALIASES
     assert f"id-{overflow - 1}" in main.KNOWN_ALIASES
+
+
+def test_both_die_and_stop_remove_the_alias_for_a_deleted_container(monkeypatch, caplog):
+    """
+    Docker sends `die` AND `stop` for one shutdown, so the record must survive the first.
+
+    This is the reason recall_alias_config reads the table with .get() rather than
+    .pop(). Dropping the entry on the first event would make the second log
+    "Container not found" for a container that was handled correctly a moment earlier.
+    A mutation to .pop() passed the whole suite before this test existed, because no
+    other test sends two stop events for one container ID.
+    """
+    main, fake_client = load_main(monkeypatch)
+    removals = []
+    monkeypatch.setattr(main, "process_start_event", lambda *_args: None)
+    monkeypatch.setattr(
+        main, "process_stop_event", lambda _host_override, alias: removals.append(alias)
+    )
+
+    fake_client.container = _remembering_container("abc123", "nginx", "nginx.lab.internal")
+    main.handle_container_event({"Actor": {"ID": "abc123"}, "Action": "start"})
+
+    _container_is_gone(fake_client)
+    with caplog.at_level(logging.WARNING):
+        main.handle_container_event({"Actor": {"ID": "abc123"}, "Action": "die"})
+        main.handle_container_event({"Actor": {"ID": "abc123"}, "Action": "stop"})
+
+    assert removals == ["nginx.lab.internal", "nginx.lab.internal"]
+    assert "Container not found" not in caplog.text
+
+
+def test_re_recording_a_container_makes_it_the_newest_entry(monkeypatch):
+    """
+    remember_alias_config deletes before reinserting, so a re-recorded container counts
+    as newest for eviction.
+
+    Eviction relies on dictionaries preserving insertion order. Without the delete, a
+    long-lived container that keeps being re-recorded would keep its original position
+    and be evicted ahead of entries younger than it. Removing the pop passed the whole
+    suite before this test existed, because no other test re-records an ID.
+    """
+    main, fake_client = load_main(monkeypatch)
+    monkeypatch.setattr(main, "process_start_event", lambda *_args: None)
+
+    def start(index):
+        fake_client.container = _remembering_container(
+            f"id-{index}", f"svc{index}", f"svc{index}.lab.internal"
+        )
+        main.handle_container_event({"Actor": {"ID": f"id-{index}"}, "Action": "start"})
+
+    for index in range(main.KNOWN_ALIASES_MAX):
+        start(index)
+    assert len(main.KNOWN_ALIASES) == main.KNOWN_ALIASES_MAX
+
+    # Re-record the oldest entry. It must move to the newest position.
+    start(0)
+    # One more start overflows the table by one, evicting whatever is oldest.
+    start(main.KNOWN_ALIASES_MAX)
+
+    assert len(main.KNOWN_ALIASES) == main.KNOWN_ALIASES_MAX
+    # id-0 was refreshed, so id-1 is now the oldest and is the one to go.
+    assert "id-0" in main.KNOWN_ALIASES
+    assert "id-1" not in main.KNOWN_ALIASES
 
 
 def test_startup_scan_remembers_aliases_for_containers_it_did_not_see_start(monkeypatch):


### PR DESCRIPTION
Two developer-machine findings from the security review. Neither runs in CI, which needs KVM.

## 1. The pfRest package was installed with no checksum

`bootstrap.sh` verifies the pfSense installer image against a SHA256 and then, **twenty lines later**, fetches the pfRest package with no checksum at all — and installs it as root inside the VM with `pkg-static add`.

A GitHub release asset is mutable: the publisher can replace it without moving the tag, so `RESTAPI_VERSION="v2.4.3"` is not an immutable reference the way the actionlint pin is. Transport is TLS-verified, so this was never remotely exploitable; it was an inconsistency with the file's own standard.

`RESTAPI_SHA256` comes from the asset's `digest` field, which **GitHub computes**, rather than from hashing whatever happened to land on disk first — that would have been trust-on-first-use. Verified it matches the existing copy:

```
local copy:  69f84530890c62dc0209e188af3f697fa1952b9de532720cfc6e3ebe42331438
github says: 69f84530890c62dc0209e188af3f697fa1952b9de532720cfc6e3ebe42331438
```

The command to re-derive it on a version bump is in the comment, beside the existing note that the two versions move together.

## 2. smoke.sh started the relay and never stopped it

The relay binds the Docker bridge address — reachable by **every container on the default network**, not just this service — and forwards to a firewall keeping pfSense's default `admin`/`pfsense` credentials with login protection disabled. Left running on a machine that also runs untrusted containers, a test fixture becomes a standing credential-free path to a firewall admin GUI.

### My first attempt broke the smoke test, and the live run caught it

Worth recording, because it is a trap in the script's shape. The exit trap is `cleanup` — but `smoke.sh` *also* calls `cleanup` mid-script to clear leftover containers before starting the service, which happens **after** the relay starts. Adding the relay stop there shut the relay down seconds after it came up:

```
FAIL  the service logs the alias as added (gave up after 120s)
FAIL  smoke.lab.internal resolves (gave up after 120s)
...
error: 6 assertion(s) failed
```

Split into `cleanup` (containers only, safe to call at any point) and `on_exit` (teardown, trap only). Green afterwards, with the relay confirmed down.

This is precisely the class of thing the unit suite cannot see, and the reason `AGENTS.md` asks for a live run.

## Documentation

`test-env/README.md` now says to stop the relay by hand if you start it by hand, and why.

## Verification

shellcheck clean; the checksum step passes against the real package; `relay.sh stop` is idempotent, so the trap is safe when the relay never started; full smoke run green with the relay down afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)