### PR TITLE
Pin six guards that did not fail under their own mutation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ uv pip install -r requirements.txt -r requirements-dev.txt
 
 ```bash
 .venv/bin/python -m py_compile main.py pfsense.py   # required after changing either Python file
-.venv/bin/python -m pytest                          # full suite (164 tests)
+.venv/bin/python -m pytest                          # full suite (169 tests)
 .venv/bin/python -m pytest --cov --cov-report=term-missing   # with the coverage gate
 .venv/bin/python -m pytest tests/test_main.py::test_parse_alias_labels_returns_alias_config   # single test
 .venv/bin/python -m pylint main.py pfsense.py       # must stay at 10.00/10
@@ -103,7 +103,7 @@ Reading env vars, `docker.from_env()`, and `signal.signal()` registration all ha
 Deliberately asymmetric — keep it that way:
 
 - pfSense API failures **log and return `False`**; they never raise, so one bad container can't kill the service.
-- `_request` retries `requests.RequestException`, `OSError` and `ValueError` up to `API_REQUEST_ATTEMPTS` (3) with a 1s sleep. `raise_for_status()` is called *outside* the retry, so HTTP error statuses are not retried. Tests monkeypatch `pfsense.time.sleep`.
+- `_request` retries everything in `API_ERRORS` up to `API_REQUEST_ATTEMPTS` (3) with a 1s sleep. `raise_for_status()` is called *outside* the retry, so HTTP error statuses are not retried. Tests monkeypatch `pfsense.time.sleep`.
 - Docker event-stream errors **re-raise** out of `main()`; `run()` catches and exits non-zero so the container restarts.
 
 ### Mutations are staged, then applied
@@ -171,7 +171,7 @@ For the same reason, **a failed flush keeps its changes pending**. `flush_pendin
 
 `get_all_host_overrides()` validates the payload shape — it returns `[]` for a non-list `data` and drops non-dict entries — and every accessor uses `.get()` rather than indexing. A well-formed 200 with an unexpected body previously raised `KeyError`/`TypeError` straight out of this module, which `main()` does not catch, exiting the service instead of logging and carrying on. An API schema change must degrade to a warning, never a crash loop.
 
-`_request` catches `OSError` **and `ValueError`** as well as `RequestException`. `ValueError` is there because `http.client` raises `UnicodeEncodeError` — a `ValueError`, not a `RequestException` — when a header will not encode as latin-1, and that escaped every handler up to `run()`, which exits the process. The rule the code comment states and this file must not lose: **the mutation and apply paths must not catch strictly less than the read path.** `get_all_host_overrides` already caught `ValueError`, which is the only reason the escape was unreachable in practice rather than by design; `test_a_value_error_in_a_mutation_does_not_escape` pins it. `requests` raises a **bare `OSError`** when `verify` names an unreadable CA bundle, which used to escape every public method and crash-loop the container — pushing operators toward disabling TLS verification to get the service running. `main.py` also checks `PFSENSE_CA_BUNDLE` is readable at startup and exits with a clear message, since that is a configuration error worth failing loudly on.
+Every handler that wraps an API call uses the single `API_ERRORS` tuple — `(RequestException, OSError, ValueError, AttributeError)`. That is structural, not a convention: this file previously *stated* that the mutation and apply paths must not catch strictly less than the read path, and the code did not hold it — four handlers had four different tuples and the narrowest caught only `RequestException`. Nothing was live, because `_request` normalises everything beneath them, but a rule asserted in prose and contradicted by the source is worse than no rule. One tuple makes the claim true by construction. `ValueError` is there because `http.client` raises `UnicodeEncodeError` — a `ValueError`, not a `RequestException` — when a header will not encode as latin-1, and that escaped every handler up to `run()`, which exits the process. The rule the code comment states and this file must not lose: **the mutation and apply paths must not catch strictly less than the read path.** `get_all_host_overrides` already caught `ValueError`, which is the only reason the escape was unreachable in practice rather than by design; `test_a_value_error_in_a_mutation_does_not_escape` pins it. `requests` raises a **bare `OSError`** when `verify` names an unreadable CA bundle, which used to escape every public method and crash-loop the container — pushing operators toward disabling TLS verification to get the service running. `main.py` also checks `PFSENSE_CA_BUNDLE` is readable at startup and exits with a clear message, since that is a configuration error worth failing loudly on.
 
 `add_host_override_alias` first calls `find_host_name(alias_fqdn)` to reject an alias already used as a host override or alias anywhere, then resolves the parent host override — the override must already exist in pfSense; this service never creates one.
 

--- a/pfsense.py
+++ b/pfsense.py
@@ -63,6 +63,19 @@ logger = logging.getLogger(__name__)
 
 API_REQUEST_ATTEMPTS = 3
 API_RETRY_DELAY_SECONDS = 1
+
+# One tuple for every handler that wraps an API call, so no path can catch strictly
+# less than another. AGENTS.md used to state that as a rule and the code did not hold
+# it: four handlers had four different tuples, and the narrowest caught only
+# RequestException. Nothing was live -- _request normalises everything below these --
+# but a rule stated in prose and contradicted by the source is worse than no rule.
+#
+# Each member earns its place. OSError: requests raises a bare one when `verify` names
+# an unreadable CA bundle. ValueError: http.client raises UnicodeEncodeError, a
+# ValueError, when a header will not encode as latin-1, and json() raises
+# JSONDecodeError, also a ValueError. AttributeError: a malformed response body makes
+# .get() calls fail on a non-dict.
+API_ERRORS = (requests.RequestException, OSError, ValueError, AttributeError)
 # Applying is asynchronous: the POST returns before unbound has finished
 # reloading, so confirm with a bounded GET poll rather than fire-and-forget.
 APPLY_POLL_ATTEMPTS = 15
@@ -251,7 +264,7 @@ class PFSense:
             # failure logs and returns False. The read path already caught ValueError,
             # which is the only reason this was not reachable in practice; the mutation
             # and apply paths must not catch strictly less than it.
-            except (requests.RequestException, OSError, ValueError) as e:
+            except API_ERRORS as e:
                 if attempt == attempts:
                     self._handle_api_error(e, context)
                     return None
@@ -299,7 +312,7 @@ class PFSense:
             if response is None:
                 return False
             response.raise_for_status()
-        except requests.RequestException as e:
+        except API_ERRORS as e:
             self._handle_api_error(e, "apply_changes")
             return False
 
@@ -336,7 +349,7 @@ class PFSense:
             response.raise_for_status()
             data = response.json().get('data', {})
             return data.get('applied') is True
-        except (requests.RequestException, ValueError, AttributeError) as e:
+        except API_ERRORS as e:
             self._handle_api_error(e, "apply_changes_status")
             return False
 
@@ -427,7 +440,7 @@ class PFSense:
                 return []
             response.raise_for_status()
             data = response.json().get('data', [])
-        except (requests.RequestException, OSError, ValueError, AttributeError) as e:
+        except API_ERRORS as e:
             self._handle_api_error(e, "get_all_host_overrides")
             return []
 
@@ -519,7 +532,7 @@ class PFSense:
                 return False
             response.raise_for_status()
 
-        except (requests.RequestException, OSError) as e:
+        except API_ERRORS as e:
             self._handle_api_error(e, context)
             return False
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -85,6 +85,16 @@ def test_parse_alias_labels_returns_alias_config(monkeypatch):
 
 
 def test_tls_verification_env_defaults_to_true_and_only_false_disables(monkeypatch):
+    """
+    Fail-secure: exactly one spelling disables verification, case-insensitively.
+
+    The name of this test claimed more than its body did. It checked the default,
+    "not-a-bool", and "false" -- but nothing asserted that a DIFFERENT falsy spelling
+    still verifies, so widening the check to `not in ("false", "0", "no")` left the
+    suite green. That is the shape a well-meant usability PR takes, and it silently
+    turns off certificate verification for an operator who set PFSENSE_VERIFY_SSL=0
+    expecting it to be ignored.
+    """
     main, _fake_client = load_main(monkeypatch)
     assert main.PFSENSE_VERIFY_SSL is True
 
@@ -93,6 +103,17 @@ def test_tls_verification_env_defaults_to_true_and_only_false_disables(monkeypat
 
     main, _fake_client = load_main(monkeypatch, verify_ssl="false")
     assert main.PFSENSE_VERIFY_SSL is False
+
+    # Case-insensitivity is deliberate, and pins the .lower() call.
+    for spelling in ("FALSE", "False", "FaLsE"):
+        main, _fake_client = load_main(monkeypatch, verify_ssl=spelling)
+        assert main.PFSENSE_VERIFY_SSL is False, spelling
+
+    # Every OTHER falsy-looking spelling must still verify. This is the direction that
+    # matters: an accidental widening here weakens TLS.
+    for spelling in ("0", "no", "off", "n", "disabled", "", " false ", "false "):
+        main, _fake_client = load_main(monkeypatch, verify_ssl=spelling)
+        assert main.PFSENSE_VERIFY_SSL is True, spelling
 
 
 def test_parse_alias_labels_ignores_incomplete_labels(monkeypatch):
@@ -984,6 +1005,31 @@ def test_a_burst_of_starts_costs_two_applies_not_twenty(monkeypatch):
     assert nameserver.flush_applies == 1
     assert nameserver.total_applies == 2
     assert main.PENDING_CHANGES == 0
+
+
+def test_pending_changes_force_coalescing_even_after_a_quiet_period(monkeypatch):
+    """
+    should_apply_immediately must say no while anything is pending, regardless of clock.
+
+    Deleting `if PENDING_CHANGES: return False` left the suite green, because the burst
+    test is covered redundantly by the LAST_APPLY_AT arithmetic. The guard only bites
+    when changes are pending AND the last apply is old or absent -- which is exactly a
+    pfSense outage being retried by _defer_retry(). Without it, every new container
+    event during that outage would attempt a full apply inline in the event loop: a
+    POST plus up to fifteen one-second polls, per event.
+    """
+    main, _fake_client = load_main(monkeypatch)
+    nameserver = RecordingNameserver(apply_result=False)
+    main.NAMESERVER = nameserver
+
+    # One change lands but its apply fails, so it stays pending.
+    main.process_start_event("caddy.lab.internal", "a.lab.internal", "a")
+    assert main.PENDING_CHANGES == 1
+
+    # Make the last apply look long ago, which is what _defer_retry leaves behind.
+    monkeypatch.setattr(main, "LAST_APPLY_AT", None)
+
+    assert main.should_apply_immediately() is False
 
 
 def test_pending_changes_are_not_flushed_before_the_quiet_period(monkeypatch):

--- a/tests/test_pfsense.py
+++ b/tests/test_pfsense.py
@@ -681,22 +681,173 @@ def test_add_host_override_alias_returns_false_for_malformed_alias_fqdn(monkeypa
     assert not client.add_host_override_alias("caddy.lab.internal", "nginx")
 
 
-def test_add_host_override_alias_rejects_hostile_fqdn_values(monkeypatch):
+def test_a_rejected_fqdn_never_reaches_the_api(monkeypatch):
+    """
+    The payload barrier is proven by NO REQUEST BEING MADE, not by a False return.
+
+    The superseded version of this test asserted only `not add_host_override_alias(...)`
+    and never stubbed requests.post. When the barrier admitted a value, the call fell
+    through to a real HTTPS request to pfsense.lab.internal, which failed and returned
+    False anyway -- so the assertion could not tell "rejected by the barrier" from "the
+    network was down". Widening DNS_LABEL_PATTERN to admit a double quote left the whole
+    suite green, and the hostile value reached the payload:
+
+        {'parent_id': '12', 'host': 'ngi"nx', 'domain': 'lab.internal', 'descr': ''}
+
+    That character matters specifically: AGENTS.md records that an alias host is written
+    into unbound.conf's double-quoted local-data: directive with no escaping, and that a
+    malformed name leaves unbound not running at all -- a firewall-wide DNS outage that
+    POST /dns_resolver/apply still reports as applied.
+    """
+    requests_made = []
+
+    def record(**kwargs):
+        requests_made.append(kwargs)
+        return FakeResponse({"data": []})
+
+    monkeypatch.setattr("pfsense.requests.post", record)
+    monkeypatch.setattr("pfsense.requests.delete", record)
+    monkeypatch.setattr("pfsense.time.sleep", lambda _seconds: None)
+
     client = PFSense("pfsense.lab.internal", "secret-token")
     client.get_all_host_overrides = lambda: [
-        {
-            "id": 12,
-            "host": "caddy",
-            "domain": "lab.internal",
-            "aliases": [],
-        }
+        {"id": 12, "host": "caddy", "domain": "lab.internal", "aliases": []}
     ]
 
-    assert not client.add_host_override_alias("caddy.lab.internal", "bad alias.lab.internal")
-    assert not client.add_host_override_alias("caddy.lab.internal", "bad\nalias.lab.internal")
-    assert not client.add_host_override_alias("caddy.lab.internal", "bad..alias.lab.internal")
-    assert not client.add_host_override_alias("caddy.lab.internal", "-bad.lab.internal")
-    assert not client.add_host_override_alias("caddy.lab.internal", "bad-.lab.internal")
+    hostile = [
+        'ngi"nx.lab.internal',              # the unbound.conf quoting character
+        "bad alias.lab.internal",           # space
+        "bad\nalias.lab.internal",          # embedded newline
+        "trailing.lab.internal\n",          # trailing newline: $ matches before it
+        "bad..alias.lab.internal",          # empty label
+        "-bad.lab.internal",                # leading hyphen
+        "bad-.lab.internal",                # trailing hyphen
+        "bad;alias.lab.internal",           # shell metacharacter
+        "a" * 64 + ".lab.internal",         # label over 63
+        ("a" * 63 + ".") * 4 + "lab.internal",  # FQDN over 253
+        "single",                           # fewer than two labels
+    ]
+
+    for fqdn in hostile:
+        assert client.add_host_override_alias("caddy.lab.internal", fqdn) is False, fqdn
+        assert client.del_host_override_alias("caddy.lab.internal", fqdn) is False, fqdn
+
+    # The assertion that actually pins the barrier.
+    assert requests_made == [], requests_made
+    assert client.unapplied_changes is False
+    assert client.change_count == 0
+
+
+def test_a_non_iterable_data_payload_does_not_crash_the_service(monkeypatch):
+    """
+    The shape that actually needs the isinstance guard is a non-iterable `data`.
+
+    The existing corpus used {"data": {...}} for its "not a list" case, but a dict IS
+    iterable, so the comprehension filters it to [] with or without the guard --
+    deleting the guard left the whole suite green. `{"data": null}` is entirely
+    plausible from a REST API with nothing configured, and it raises TypeError from the
+    comprehension, which is OUTSIDE the try/except. That escapes every handler up to
+    run() and exits the process: the crash loop AGENTS.md says must degrade to a
+    warning.
+    """
+    monkeypatch.setattr("pfsense.time.sleep", lambda _seconds: None)
+
+    for payload in ({"data": None}, {"data": 5}, {"data": True}):
+        monkeypatch.setattr("pfsense.requests.get", lambda **_kwargs: FakeResponse(payload))
+        client = PFSense("pfsense.lab.internal", "secret-token")
+        # Must degrade to an empty list, not raise.
+        assert client.get_all_host_overrides() == [], payload
+
+
+def test_a_non_iterable_aliases_value_does_not_crash_the_service(monkeypatch):
+    """
+    Same shape one level down, and this one has no handler at all above it.
+
+    find_alias_in_host_override is called directly by del_host_override_alias with no
+    try/except in between, so a TypeError here goes straight out of the module.
+    """
+    client = PFSense("pfsense.lab.internal", "secret-token")
+
+    for aliases in (None, 5, True):
+        override = {"id": 1, "host": "caddy", "domain": "lab.internal", "aliases": aliases}
+        assert client.find_alias_in_host_override(override, "x.lab.internal") is None, aliases
+
+
+def test_redaction_runs_before_sanitizing(monkeypatch, caplog):
+    """
+    The order in _handle_api_error is load-bearing and was previously untested.
+
+    Two ways the swapped order leaks, both confirmed:
+
+    1. sanitize_for_log escapes backslashes, so a token containing one is rendered
+       `a\\b` and the literal match then misses it entirely.
+    2. sanitize_for_log truncates at LOG_VALUE_MAX_CHARS, so a token straddling that
+       boundary is cut in half and the surviving fragment is logged.
+
+    Redacting first sees the whole, unescaped string, so neither applies.
+    """
+    monkeypatch.setattr("pfsense.time.sleep", lambda _seconds: None)
+
+    # A backslash survives main.py's printability and latin-1 gates, so this is a
+    # token an operator could really be running with.
+    token = "SECRET\\WITH\\BACKSLASH"
+
+    def fake_get(**_kwargs):
+        raise ValueError(f"Invalid header value {token}")
+
+    monkeypatch.setattr("pfsense.requests.get", fake_get)
+    client = PFSense("pfsense.lab.internal", token)
+
+    with caplog.at_level(logging.ERROR):
+        assert client.get_all_host_overrides() == []
+
+    assert "SECRET" not in caplog.text
+    assert "BACKSLASH" not in caplog.text
+
+    # And a token past the truncation boundary.
+    caplog.clear()
+    long_token = "T" * 40
+    padding = "x" * (pfsense.LOG_VALUE_MAX_CHARS - 20)
+
+    def fake_get_long(**_kwargs):
+        raise ValueError(f"{padding}{long_token}{padding}")
+
+    monkeypatch.setattr("pfsense.requests.get", fake_get_long)
+    client = PFSense("pfsense.lab.internal", long_token)
+
+    with caplog.at_level(logging.ERROR):
+        assert client.get_all_host_overrides() == []
+
+    # No run of the token long enough to be recognisable may survive.
+    assert "T" * 20 not in caplog.text
+
+
+def test_a_valid_fqdn_does_reach_the_api(monkeypatch):
+    """
+    The companion to the above: proof the rejection test is not vacuous the other way.
+
+    A test that asserts "no request was made" passes trivially if nothing can ever make
+    a request. This pins that the same setup does issue one for a well-formed name.
+    """
+    requests_made = []
+
+    def record(**kwargs):
+        requests_made.append(kwargs)
+        return FakeResponse({"data": []})
+
+    monkeypatch.setattr("pfsense.requests.post", record)
+    monkeypatch.setattr("pfsense.time.sleep", lambda _seconds: None)
+
+    client = PFSense("pfsense.lab.internal", "secret-token")
+    client.get_all_host_overrides = lambda: [
+        {"id": 12, "host": "caddy", "domain": "lab.internal", "aliases": []}
+    ]
+
+    assert client.add_host_override_alias("caddy.lab.internal", "ok.lab.internal", apply=False)
+
+    assert len(requests_made) == 1
+    assert requests_made[0]["json"]["host"] == "ok"
+    assert requests_made[0]["json"]["domain"] == "lab.internal"
 
 
 def test_del_host_override_alias_constructs_delete_and_apply_requests(monkeypatch):


### PR DESCRIPTION
Fourth-pass review. **The code converged** — no defect found in `main.py` or `pfsense.py`. **The test contract had not.** Six guards survived deliberate mutation of the source with the whole suite green.

## 1. The payload injection barrier — the control this repo documents most heavily

Widening `DNS_LABEL_PATTERN` to admit a double quote left **all 164 tests passing**, and the hostile value reached the payload:

```
{'parent_id': '12', 'host': 'ngi"nx', 'domain': 'lab.internal', 'descr': ''}
```

That character specifically: an alias host is written into `unbound.conf`'s double-quoted `local-data:` directive with no escaping, and a malformed name leaves unbound **not running at all** — a firewall-wide DNS outage that `POST /dns_resolver/apply` still reports as `applied`.

### The test passed for the wrong reason

`test_add_host_override_alias_rejects_hostile_fqdn_values` asserted only `not add_host_override_alias(...)` and **never stubbed `requests.post`**. When the barrier admitted a value, the call fell through to a real HTTPS request to `pfsense.lab.internal`, which failed and returned `False` anyway. The assertion could not distinguish *rejected by the barrier* from *the network was down* — and on regression it would have started making real outbound calls from CI, with retries and sleeps.

It now asserts **no request is made**, across eleven hostile shapes, for both mutators — with a companion test proving a valid name *does* reach the API, so it cannot pass vacuously in the other direction either.

## The other five

- **API-response shape guards** were pinned only by `{"data": {...}}` — a dict is iterable, so the comprehension filters it to `[]` with or without the guard. `{"data": null}` is what actually crashes, and the `TypeError` is raised **outside** the `try/except`: the crash loop `AGENTS.md` says must degrade to a warning. Same one level down for a non-iterable `aliases`, which has no handler above it at all.
- **`PFSENSE_VERIFY_SSL` was unpinned in the weakening direction.** The test's name said "only false disables"; its body never checked that a *different* falsy spelling still verifies, so widening to `("false", "0", "no")` stayed green. That is the shape a well-meant usability PR takes.
- **`_redact_token`'s ordering is load-bearing and untested.** Sanitizing first escapes a backslash in the token so the literal match misses it, and truncates a long message so a token fragment survives past the 512-character cap. Both directions now pinned.
- **`should_apply_immediately`'s `PENDING_CHANGES` guard survived deletion** — the burst case is covered redundantly by the `LAST_APPLY_AT` arithmetic. It only bites during a pfSense outage being retried, where without it every event would attempt a full apply inline in the event loop: a POST plus up to fifteen one-second polls, per event.
- **`AGENTS.md` stated an invariant the code did not hold.** "The mutation and apply paths must not catch strictly less than the read path" — four handlers had four different tuples, the narrowest catching only `RequestException`. Nothing was live, since `_request` normalises everything beneath them, but a rule asserted in prose and contradicted by the source is worse than no rule. A single `API_ERRORS` tuple now makes it true **by construction rather than by promise**.

## Every fix was mutation-tested

Each of the six mutations was re-applied after the fix and confirmed to fail exactly one test:

```
widen DNS_LABEL_PATTERN     -> 1 failed
fullmatch -> match          -> 1 failed
drop isinstance(data, list) -> 1 failed
swap redaction/sanitize     -> 1 failed
widen VERIFY_SSL spellings  -> 1 failed
delete PENDING_CHANGES guard-> 1 failed
restored                    -> 169 passed
```

A guard that does not fail under its own mutation is not a guard.

## One process note

Mid-way through, the redaction-order fix appeared broken — correct in source, unredacted in output. The cause was a stale `__pycache__` left by `python -m py_compile` shadowing the edits. Worth knowing before chasing a phantom: clear `__pycache__` when a verified-correct change appears not to take effect.

## Verification

169 tests, pylint 10.00/10, coverage gate green, shellcheck, `docker build`, and the **full live VM run green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)