### PR TITLE
Pin TLS and the status check on the write paths, and three timer invariants

### DIFF
--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -15,7 +15,7 @@ A daemon holding a pfSense API token, mounting `/var/run/docker.sock`, and turni
 
 It authenticates DNS changes on a firewall. It must never reach logs, error messages, exception text, or CI output. `_handle_api_error` deliberately logs the exception and status code but **not** `response.text`, and `test_http_error_logs_status_without_response_body` pins that. Any new error path, debug line, or re-raise that widens what gets logged is a finding. So is anything that puts the token in a URL rather than the `X-API-Key` header.
 
-`PFSense._headers()` is the single construction point for those headers, and `X-API-Key` should appear exactly once in `pfsense.py` — inside it. A request that builds the header dict inline is a finding even when it is byte-identical today, because it silently opts out of any future hardening of `_headers()`. `grep -c X-API-Key pfsense.py` is the check.
+`PFSense._headers()` is the single construction point for those headers, and `X-API-Key` should appear exactly once in `pfsense.py` — inside it. A request that builds the header dict inline is a finding even when it is byte-identical today, because it silently opts out of any future hardening of `_headers()`. `grep -c "'X-API-Key':" pfsense.py` is the check, and it must return exactly 1 — the dict key, not the bare string. Do not use `grep -c X-API-Key`: that counts prose too. The header name now appears in a comment explaining `allow_redirects=False`, so the bare-string count is 2 and reads as a finding when nothing is wrong. A mechanical check stated at the wrong value either false-alarms or teaches the next reviewer to ignore its own number.
 
 ### 2. TLS trust
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ uv pip install -r requirements.txt -r requirements-dev.txt
 
 ```bash
 .venv/bin/python -m py_compile main.py pfsense.py   # required after changing either Python file
-.venv/bin/python -m pytest                          # full suite (169 tests)
+.venv/bin/python -m pytest                          # full suite (173 tests)
 .venv/bin/python -m pytest --cov --cov-report=term-missing   # with the coverage gate
 .venv/bin/python -m pytest tests/test_main.py::test_parse_alias_labels_returns_alias_config   # single test
 .venv/bin/python -m pylint main.py pfsense.py       # must stay at 10.00/10
@@ -161,6 +161,8 @@ Tests drive `main()` by monkeypatching `main.iter_events` with a finite iterable
 
 With `apply=False`, a `True` return means **staged in the pfSense configuration but not yet live**. Staged changes persist and go live on the next successful apply. The log says "staged", not "added"/"removed", because an operator reading "removed" while the name still resolves is worse than no message at all.
 
+**A timer property needs a controlled clock, not an edited threshold.** Several coalescing invariants are invisible otherwise, because moving `APPLY_QUIET_SECONDS` proves only that the threshold is read, not that a timestamp moved — and in a fast test the timestamps are microseconds apart, so wall time cannot separate them either. That is how `test_a_failed_flush_defers_the_next_attempt` came to name a property it could not detect: gutting `_defer_retry` to `pass` left the whole suite green. `tests/test_main.py`'s `FakeClock` patches `main.time.monotonic`; use it for anything involving `PENDING_SINCE`, `LAST_CHANGE_AT`, or `LAST_APPLY_AT`.
+
 **`PFSense.unapplied_changes` is the source of truth, not the return value.** A mutation can land while its apply fails, which returns `False` even though something is now staged. `unapplied_changes` is set as soon as the mutation POST succeeds and cleared only by a confirmed apply. `main._record_change_outcome()` consults it rather than the boolean — trusting the boolean stranded those changes, because nothing was pending so nothing ever retried and the alias never went live.
 
 For the same reason, **a failed flush keeps its changes pending**. `flush_pending_changes()` calls `_defer_retry()` rather than `_record_applied()` when the apply fails, so a later tick or the shutdown flush retries. `_defer_retry()` pushes the timers out a full quiet window so a pfSense outage is not retried on every two-second window tick.
@@ -261,7 +263,7 @@ The intended order for a behavior change is **planner → tester → implementer
 
 **The contract:** the tester owns everything under `tests/`. The implementer may not create, edit, or delete those files — not to fix a failure, not to soften an assertion, not to add a skip. When the implementer believes a test encodes the wrong requirement it escalates to the planner, which rules one of three ways: the test is right and the implementation must change (the default), the test is wrong and the *tester* revises it, or the plan was ambiguous and the plan changes first. Difficulty satisfying a test is not evidence that the test is wrong.
 
-This matters here because the assertions are deliberately precise — `tests/test_pfsense.py` pins exact `requests` call sequences and kwargs, which is what makes a dropped `/apply` call or a weakened TLS `verify` fail loudly instead of silently. An implementer that can edit the test can erase the safety net rather than satisfy it.
+This matters here because the assertions are deliberately precise — `tests/test_pfsense.py` pins exact `requests` call sequences and kwargs, which is what makes a dropped `/apply` call or a weakened TLS `verify` fail loudly instead of silently. **A `verify` assertion is only meaningful against a CA bundle path.** A test that builds its client with `verify_ssl=False` and then asserts `"verify": False` cannot tell "tracks `self.verify_ssl`" from "is hardcoded to a constant" — hardcoding `verify=False` in `_mutate_alias` and in `apply_changes`' POST passed the entire suite for exactly that reason, on the two requests that mutate the firewall. A bundle path is a value neither `True` nor `False` can accidentally match, so use one whenever pinning `verify`. An implementer that can edit the test can erase the safety net rather than satisfy it.
 
 The reviewer enforces this by checking `git diff main...HEAD -- tests/` and confirming any change there traces to a planner ruling. A human working directly is bound by the same rule: change tests deliberately, as a decision, not as a way to get to green.
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1169,24 +1169,147 @@ def test_a_stranded_change_is_retried_rather_than_lost(monkeypatch):
     assert main.PENDING_CHANGES == 0
 
 
+class FakeClock:
+    """
+    A controllable time.monotonic, so coalescing timers can be tested at all.
+
+    Several timer properties are invisible without one: a test that fakes the passage
+    of time by editing APPLY_QUIET_SECONDS proves only that the threshold is read, not
+    that the timestamps moved. That is how the deferral test below came to pass while
+    detecting nothing.
+    """
+
+    def __init__(self, start=1000.0):
+        self.now = start
+
+    def __call__(self):
+        return self.now
+
+    def advance(self, seconds):
+        self.now += seconds
+
+
+def _stage_one_change(main, nameserver, clock):
+    """Stage a change without an immediate apply, so the coalescer holds it."""
+    main.LAST_APPLY_AT = clock.now
+    main.process_start_event("caddy.lab.internal", "a.lab.internal", "a")
+    assert nameserver.immediate_applies == 0
+
+
 def test_a_failed_flush_defers_the_next_attempt(monkeypatch):
-    """A pfSense outage must not be retried on every two-second window tick."""
+    """
+    A pfSense outage must not be retried on every two-second window tick.
+
+    The previous version of this test named the property but could not detect its loss.
+    It restored APPLY_QUIET_SECONDS to 3600 before the second flush, so the quiet-window
+    check failed whether or not _defer_retry had pushed the timestamps -- gutting
+    _defer_retry to `pass` left the whole suite green. Both timestamps are microseconds
+    apart in a fast test, so real wall time cannot separate them either.
+
+    With a controlled clock the deferral is observable: after a failed flush, a tick
+    inside the quiet window must not retry, and one after it must.
+    """
+    clock = FakeClock()
+    monkeypatch.setattr("main.time.monotonic", clock)
     main, _fake_client = load_main(monkeypatch)
     nameserver = RecordingNameserver(apply_result=False)
     main.NAMESERVER = nameserver
-    monkeypatch.setattr(main, "APPLY_QUIET_SECONDS", 3600.0)
+    monkeypatch.setattr(main, "APPLY_QUIET_SECONDS", 10.0)
     monkeypatch.setattr(main, "APPLY_MAX_WAIT_SECONDS", 3600.0)
 
-    main.process_start_event("caddy.lab.internal", "a.lab.internal", "a")
-    monkeypatch.setattr(main, "APPLY_QUIET_SECONDS", 0.0)
+    _stage_one_change(main, nameserver, clock)
+
+    # The quiet window elapses; the flush runs and fails.
+    clock.advance(11)
     main.flush_pending_changes()
     assert nameserver.flush_applies == 1
 
-    # Timers were pushed out, so an immediate second tick does not retry.
+    # A tick well inside the new quiet window must NOT retry. Without _defer_retry the
+    # original LAST_CHANGE_AT is still 11s old, so this would fire immediately.
+    clock.advance(5)
+    main.flush_pending_changes()
+    assert nameserver.flush_applies == 1, "retried before the deferral elapsed"
+
+    # Past the deferred window, it retries.
+    clock.advance(6)
+    main.flush_pending_changes()
+    assert nameserver.flush_applies == 2
+    assert main.PENDING_CHANGES == 1
+
+
+def test_a_second_staged_change_does_not_restart_the_starvation_cap(monkeypatch):
+    """
+    _record_staged sets PENDING_SINCE only when it is None, and that guard is the cap.
+
+    Resetting it on every change leaves APPLY_MAX_WAIT_SECONDS unable to ever fire:
+    continuous churn keeps pushing the start of the window forward, so staged changes
+    are never applied by a tick. Measured against a restart-looping container, the
+    mutated form performed zero applies and accumulated sixty pending changes where the
+    real code applied four times.
+    """
+    clock = FakeClock()
+    monkeypatch.setattr("main.time.monotonic", clock)
+    main, _fake_client = load_main(monkeypatch)
+    nameserver = RecordingNameserver()
+    main.NAMESERVER = nameserver
+    # Quiet never fires, so only the max-wait cap can flush.
     monkeypatch.setattr(main, "APPLY_QUIET_SECONDS", 3600.0)
+    monkeypatch.setattr(main, "APPLY_MAX_WAIT_SECONDS", 60.0)
+
+    _stage_one_change(main, nameserver, clock)
+    started_at = main.PENDING_SINCE
+
+    # Churn keeps arriving, well inside the cap.
+    for _ in range(5):
+        clock.advance(10)
+        main.process_start_event("caddy.lab.internal", "b.lab.internal", "b")
+
+    # The window must still be measured from the FIRST staged change.
+    assert main.PENDING_SINCE == started_at
+
+    # 50s in, the cap has not elapsed.
+    main.flush_pending_changes()
+    assert nameserver.flush_applies == 0
+
+    # Past 60s from the first change, it must fire despite the continuing churn.
+    clock.advance(11)
     main.flush_pending_changes()
     assert nameserver.flush_applies == 1
-    assert main.PENDING_CHANGES == 1
+
+
+def test_a_confirmed_apply_clears_the_coalescing_timers(monkeypatch):
+    """
+    _record_applied must clear PENDING_SINCE and LAST_CHANGE_AT, not just the count.
+
+    Leaving them set makes the max-wait branch fire on the first tick of every later
+    burst, because PENDING_SINCE is still pointing at the previous one. Measured over
+    the same churn, that turned four applies into forty-eight -- twelve times the unbound
+    reloads coalescing exists to avoid. No test ran two bursts through one module
+    instance, and in a freshly imported main PENDING_SINCE is None, so a first burst
+    behaves identically either way.
+    """
+    clock = FakeClock()
+    monkeypatch.setattr("main.time.monotonic", clock)
+    main, _fake_client = load_main(monkeypatch)
+    nameserver = RecordingNameserver()
+    main.NAMESERVER = nameserver
+    monkeypatch.setattr(main, "APPLY_QUIET_SECONDS", 10.0)
+    monkeypatch.setattr(main, "APPLY_MAX_WAIT_SECONDS", 60.0)
+
+    _stage_one_change(main, nameserver, clock)
+    clock.advance(11)
+    main.flush_pending_changes()
+
+    assert nameserver.flush_applies == 1
+    assert main.PENDING_CHANGES == 0
+    assert main.PENDING_SINCE is None
+    assert main.LAST_CHANGE_AT is None
+
+    # A second burst must be measured from its own start, not the previous one.
+    clock.advance(600)
+    _stage_one_change(main, nameserver, clock)
+    main.flush_pending_changes()
+    assert nameserver.flush_applies == 1, "second burst flushed immediately"
 
 
 def test_iter_events_yields_a_tick_after_each_window(monkeypatch):

--- a/tests/test_pfsense.py
+++ b/tests/test_pfsense.py
@@ -1443,6 +1443,96 @@ def test_staging_logs_staged_not_added(monkeypatch, caplog):
 # --- TLS verification on the apply-status poll --------------------------------
 
 
+def test_the_write_paths_track_verify_ssl_rather_than_a_constant(monkeypatch):
+    """
+    The two requests that MUTATE the firewall must verify TLS, and that was unpinned.
+
+    Hardcoding `verify=False` in both _mutate_alias and apply_changes' POST left all
+    169 tests green. The tests that looked like they covered those sites built their
+    client with verify_ssl=False, so the expected `"verify": False` was indistinguishable
+    from a hardcoded constant.
+
+    A CA bundle path is the fix, and this repository already knew it: the status-poll
+    test says so in its own docstring. The technique was simply never carried to the two
+    requests that carry the mutation -- the alias POST/DELETE and the apply POST, which
+    are exactly the calls whose credential rewrites firewall DNS.
+    """
+    bundle = "/etc/ssl/pfsense-ca.pem"
+    seen = []
+
+    def record(**kwargs):
+        seen.append((kwargs["url"].rsplit("/", 1)[-1], kwargs["verify"]))
+        return FakeResponse({"data": []})
+
+    monkeypatch.setattr("pfsense.requests.post", record)
+    monkeypatch.setattr("pfsense.requests.delete", record)
+    monkeypatch.setattr("pfsense.requests.get", applied_status_get())
+    monkeypatch.setattr("pfsense.time.sleep", lambda _seconds: None)
+
+    client = PFSense("pfsense.lab.internal", "secret-token", ca_bundle=bundle)
+    client.get_all_host_overrides = lambda: [
+        {
+            "id": 12,
+            "host": "caddy",
+            "domain": "lab.internal",
+            "aliases": [{"id": 0, "parent_id": 12, "host": "nginx", "domain": "lab.internal"}],
+        }
+    ]
+
+    assert client.add_host_override_alias("caddy.lab.internal", "new.lab.internal") is True
+    assert client.del_host_override_alias("caddy.lab.internal", "nginx.lab.internal") is True
+
+    # Every mutating request and every apply must carry the bundle, not a constant.
+    assert seen, "no requests were made"
+    for endpoint, verify in seen:
+        assert verify == bundle, (endpoint, verify)
+    assert {endpoint for endpoint, _ in seen} == {"alias", "apply"}
+
+
+def test_a_rejected_mutation_stages_nothing_even_when_not_applying(monkeypatch):
+    """
+    raise_for_status() in _mutate_alias was unpinned: deleting it left the suite green.
+
+    The two tests that looked like they covered it called the mutator with the default
+    apply=True, so with the status check gone the *apply* still failed and their
+    `assert not ...` still held. Driving it with apply=False isolates the status check.
+
+    Without it, a 422 from pfSense -- a name it rejects, a field it dislikes -- returns
+    True, sets unapplied_changes, increments change_count, and logs "staged". The
+    coalescer then schedules an unbound reload for an alias that does not exist, and the
+    operator reads "staged" for a mutation the firewall refused.
+    """
+    monkeypatch.setattr("pfsense.time.sleep", lambda _seconds: None)
+
+    rejected = FakeResponse({})
+    rejected.status_code = 422
+    rejected.error = requests.HTTPError("422 Client Error: Unprocessable Entity")
+    rejected.error.response = rejected
+
+    monkeypatch.setattr("pfsense.requests.post", lambda **_kwargs: rejected)
+    monkeypatch.setattr("pfsense.requests.delete", lambda **_kwargs: rejected)
+
+    client = PFSense("pfsense.lab.internal", "secret-token")
+    client.get_all_host_overrides = lambda: [
+        {
+            "id": 12,
+            "host": "caddy",
+            "domain": "lab.internal",
+            "aliases": [{"id": 0, "parent_id": 12, "host": "nginx", "domain": "lab.internal"}],
+        }
+    ]
+
+    assert client.add_host_override_alias(
+        "caddy.lab.internal", "new.lab.internal", apply=False
+    ) is False
+    assert client.del_host_override_alias(
+        "caddy.lab.internal", "nginx.lab.internal", apply=False
+    ) is False
+
+    assert client.unapplied_changes is False
+    assert client.change_count == 0
+
+
 def test_apply_changes_status_poll_constructs_request(monkeypatch):
     """
     The status poll is the newest request site and was the only one with no exact-call


### PR DESCRIPTION
Fifth-pass review. The code converged again — no defect in either module — but a 142-mutation sweep found five more guards that do not fail under their own mutation. **Two are high severity.** No production code changes.

## 1. HIGH — TLS verification was unpinned on both *write* paths

Hardcoding `verify=False` in `_mutate_alias` and in `apply_changes`' POST left **all 169 tests green**. Those are the two requests that actually mutate the firewall.

```
POST  /alias   verify=False
POST  /apply   verify=False
GET   /apply   verify='/etc/ssl/pfsense-ca.pem'   <- the only one pinned
```

The tests that appeared to cover them built their client with `verify_ssl=False`, so the expected `"verify": False` was indistinguishable from a hardcoded constant.

**This repository had already diagnosed this exact failure mode, one call site over.** `test_apply_changes_status_poll_constructs_request` says so in its own docstring — *"Mutation testing proved a hardcoded `verify=False` there passed the whole suite"* — and uses a CA bundle path because it *"is a verify value that neither True nor False can accidentally match"*. The technique was never carried to the mutating requests. It is now, and `AGENTS.md` records the rule rather than leaving it in one test's docstring.

Failure scenario: an operator sets `PFSENSE_CA_BUNDLE`. Reads and the confirmation poll verify; the alias POST/DELETE and the apply POST do not. The `X-API-Key` goes out unverified on exactly the two requests that rewrite firewall DNS.

## 2. HIGH — `_mutate_alias`'s `raise_for_status()` was unpinned

The two tests that looked like they covered it used the default `apply=True`, so with the status check gone the *apply* still failed and their `assert not ...` still held. Driving it with `apply=False` isolates it.

Measured with a `422` on the alias POST:

```
ORIGINAL  returned=False  unapplied=False  change_count=0
MUTATED   returned=True   unapplied=True   change_count=1
          log: "Alias nginx.lab.internal staged for host override caddy.lab.internal."
```

A name pfSense rejects becomes a phantom staged change: the coalescer schedules an unbound reload for an alias that does not exist, and the operator reads "staged" for a mutation the firewall refused.

## 3–5. MEDIUM — three coalescing timers, all invisible without a controlled clock

Editing `APPLY_QUIET_SECONDS` proves the threshold is *read*, not that a timestamp *moved* — and in a fast test the timestamps are microseconds apart, so wall time cannot separate them either. That is how `test_a_failed_flush_defers_the_next_attempt` came to name a property it could not detect: gutting `_defer_retry` to `pass` left the suite green.

A `FakeClock` patching `main.time.monotonic` makes all three observable:

| invariant | mutated behaviour, measured over 300s of churn |
|---|---|
| `_record_staged`'s `if PENDING_SINCE is None` **is** the starvation cap | **0** applies, 60 pending — vs 4 applies |
| `_record_applied` must clear `PENDING_SINCE`/`LAST_CHANGE_AT` | **48** applies — vs 4, twelve times the reloads coalescing exists to avoid |
| `_defer_retry` pushes the next attempt out | 3 blocking retries in 6s — vs 0 |

## Every fix mutation-tested

All five mutations re-applied after the fix; each fails exactly one test:

```
verify=False on both write paths      -> 1 failed
delete raise_for_status()             -> 1 failed
_record_staged resets unconditionally -> 1 failed
_record_applied stops clearing        -> 1 failed
gut _defer_retry                      -> 1 failed
restored                              -> 173 passed
```

## Also

`.claude/agents/security-reviewer.md` told the reviewer `grep -c X-API-Key pfsense.py` should return 1. The header name now appears in a comment explaining `allow_redirects=False`, so the bare-string count is 2 and reads as a finding when nothing is wrong. Narrowed to the dict key. A mechanical check stated at the wrong value either false-alarms or teaches the next reviewer to ignore its own number.

## Verification

173 tests, pylint 10.00/10, coverage gate green, `docker build`, and the **full live VM run green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)