### PR TITLE
Move the v0.2.0 release date to 2026-08-07

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 This project uses semantic versioning. It is still on `0.x`, which means a minor
 release may contain breaking changes — and `v0.2.0` does.
 
-## v0.2.0 — 2026-08-06
+## v0.2.0 — 2026-08-07
 
 The first release since `v0.1.2` (January 2025). Read the breaking changes before
 upgrading, especially if you pull the `latest` tag.


### PR DESCRIPTION
The `v0.2.0` heading in `CHANGELOG.md` read `2026-08-06`, the date the release
notes were written rather than the date of the release. It now reads
`2026-08-07`. Bump it again if the tag slips past today.

## Nothing else needed a change

I checked the rest of the documentation against the code rather than assuming:

- `README.md`, `.env.example` and `docker-compose.yaml` each list all seven
  environment variables `main.py` reads (`PFSENSE_HOSTNAME`,
  `PFSENSE_API_TOKEN`, `PFSENSE_VERIFY_SSL`, `PFSENSE_CA_BUNDLE`,
  `ADD_ALIASES_ON_STARTUP`, `APPLY_QUIET_SECONDS`, `APPLY_MAX_WAIT_SECONDS`),
  and `README.md` lists all four `pfsense.dns.*` labels. That is the usual way
  this drifts, and it has not drifted.
- Five commits landed after the release notes were written. Four (#32–#35) are
  tests only. The fifth (#31) broadened the redirect guard from `requests`'
  `is_redirect` attribute to every 3xx status — a correctness fix inside an
  unreleased change, and the existing CHANGELOG bullet already describes the
  final behaviour, so it needs no new entry.

## Deliberately not done

No workflow change. `v0.2.0-rc2` does not match the publish job's
`^v[0-9]+\.[0-9]+\.[0-9]+$` gate, so it publishes under its own tag and leaves
`:latest` pointing at `v0.1.2` with no edit required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)