### PR TITLE
Group the artifact action updates into one pull request

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,21 @@ updates:
       prefix: chore
     labels:
       - dependencies
+    groups:
+      # The two halves of the build-once guarantee: the publish job ships the
+      # exact artifact the test job uploaded. Both steps are gated on a tag ref,
+      # so pull-request CI skips them and a bump to either action goes green
+      # having run none of its own change -- the first thing to exercise it is a
+      # release. Grouping keeps them from being merged apart and leaving the
+      # pipeline mismatched with nothing able to notice.
+      #
+      # No update-types key on purpose: omitting it groups every SemVer level,
+      # and the bumps that made this necessary (upload v4->v7, download v4->v8)
+      # were both majors.
+      artifact-actions:
+        patterns:
+          - "actions/upload-artifact"
+          - "actions/download-artifact"
 
   # Base image (python:3.14-alpine) rebuilds.
   - package-ecosystem: docker


### PR DESCRIPTION
`actions/upload-artifact` and `actions/download-artifact` are the two halves of
the build-once guarantee — the publish job ships the exact artifact the test job
uploaded. Dependabot opened them as **two separately mergeable PRs** (#37, #38),
and merging one without the other would leave the pipeline mismatched.

## Why nothing would have caught that

Both artifact steps are gated on `if: startsWith(github.ref, 'refs/tags/')`, so
on a pull request they are skipped:

- On #38, the `Upload tested image` step was **skipped** — confirmed by reading
  the job's step list, not inferred.
- On #37, `build-and-push` is skipped entirely, so `Download tested image` never
  ran at all.

Both PRs were green while executing none of their own change. The first thing to
exercise either one is a release tag push.

## The change

A `groups:` entry on the existing `github-actions` ecosystem, so the pair
arrives as one PR. Everything else still gets its own PR.

`update-types` is deliberately omitted: GitHub's reference states *"By default,
a group will include updates for all semantic versions (SemVer)"*, and the two
bumps that prompted this were both majors, so narrowing it would defeat the
purpose.

## Scope

Only the artifact pair is grouped, not all actions. `trivy-action` and
`login-action` carry unrelated risk, and bundling everything would mean one
questionable bump blocks the rest and the security scanner stops being
reviewable on its own. The coupling argument is only earned for these two.

## What this does not do

- **It does not make the bumps tested.** A grouped PR is still green while
  running neither action. Validating one still means cutting a throwaway
  pre-release tag, as was done for `v0.2.1-rc1`.
- **It is not retroactive** — #37 and #38 are already merged; this affects
  future updates.
- The grouping is not observable until Dependabot's next weekly run, so CI
  staying green is the only check available here.

## Verification

`.github/dependabot.yml` parses, the group carries exactly the two patterns,
`update-types` is absent, and the `pip` and `docker` entries are untouched. No
Python, Docker, or workflow files are involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)